### PR TITLE
[WIP] Re-design of yarpviz graph visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Temp files
+*~
+*.swp
+*.user
+*.autosave
+*Old.*
+
+# Cmake directory & files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+
+*.cbp
+*.user
+
+# directories
+build*
+graph/build*
+_site*
+
+# Merge files
+*.orig

--- a/QGVCore/QGVNode.cpp
+++ b/QGVCore/QGVNode.cpp
@@ -86,12 +86,12 @@ void QGVNode::paint(QPainter * painter, const QStyleOptionGraphicsItem * option,
 
 void QGVNode::setAttribute(const QString &name, const QString &value)
 {
-		agsafeset(_node->node(), name.toLocal8Bit().data(), value.toLocal8Bit().data(), "");
+    agsafeset(_node->node(), name.toLocal8Bit().data(), value.toLocal8Bit().data(), "");
 }
 
 QString QGVNode::getAttribute(const QString &name) const
 {
-		char* value = agget(_node->node(), name.toLocal8Bit().data());
+    char* value = agget(_node->node(), name.toLocal8Bit().data());
     if(value)
         return value;
     return QString();

--- a/QGVCore/QGVNode.cpp
+++ b/QGVCore/QGVNode.cpp
@@ -31,7 +31,7 @@ QGVNode::QGVNode(QGVNodePrivate *node, QGVScene *scene): _node(node), _scene(sce
 QGVNode::~QGVNode()
 {
     _scene->removeItem(this);
-		delete _node;
+    delete _node;
 }
 
 QString QGVNode::label() const

--- a/QGVCore/QGVScene.cpp
+++ b/QGVCore/QGVScene.cpp
@@ -29,47 +29,48 @@ License along with this library.
 #include <QGVGvcPrivate.h>
 #include <QGVEdgePrivate.h>
 #include <QGVNodePrivate.h>
+#include <QGraphicsSceneContextMenuEvent>
 
 QGVScene::QGVScene(const QString &name, QObject *parent) : QGraphicsScene(parent)
 {
-		_context = new QGVGvcPrivate(gvContext());
-		_graph = new QGVGraphPrivate(agopen(name.toLocal8Bit().data(), Agdirected, NULL));
+    _context = new QGVGvcPrivate(gvContext());
+    _graph = new QGVGraphPrivate(agopen(name.toLocal8Bit().data(), Agdirected, NULL));
     //setGraphAttribute("fontname", QFont().family());
 }
 
 QGVScene::~QGVScene()
 {
-		gvFreeLayout(_context->context(), _graph->graph());
-		agclose(_graph->graph());
-		gvFreeContext(_context->context());
+    gvFreeLayout(_context->context(), _graph->graph());
+    agclose(_graph->graph());
+    gvFreeContext(_context->context());
     delete _graph;
     delete _context;
 }
 
 void QGVScene::setGraphAttribute(const QString &name, const QString &value)
 {
-		agattr(_graph->graph(), AGRAPH, name.toLocal8Bit().data(), value.toLocal8Bit().data());
+    agattr(_graph->graph(), AGRAPH, name.toLocal8Bit().data(), value.toLocal8Bit().data());
 }
 
 void QGVScene::setNodeAttribute(const QString &name, const QString &value)
 {
-		agattr(_graph->graph(), AGNODE, name.toLocal8Bit().data(), value.toLocal8Bit().data());
+    agattr(_graph->graph(), AGNODE, name.toLocal8Bit().data(), value.toLocal8Bit().data());
 }
 
 void QGVScene::setEdgeAttribute(const QString &name, const QString &value)
 {
-		agattr(_graph->graph(), AGEDGE, name.toLocal8Bit().data(), value.toLocal8Bit().data());
+    agattr(_graph->graph(), AGEDGE, name.toLocal8Bit().data(), value.toLocal8Bit().data());
 }
 
 QGVNode *QGVScene::addNode(const QString &label)
 {
-		Agnode_t *node = agnode(_graph->graph(), NULL, TRUE);
+    Agnode_t *node = agnode(_graph->graph(), NULL, TRUE);
     if(node == NULL)
     {
         qWarning()<<"Invalid node :"<<label;
         return 0;
     }
-		QGVNode *item = new QGVNode(new QGVNodePrivate(node), this);
+    QGVNode *item = new QGVNode(new QGVNodePrivate(node), this);
     item->setLabel(label);
     addItem(item);
     _nodes.append(item);
@@ -78,14 +79,14 @@ QGVNode *QGVScene::addNode(const QString &label)
 
 QGVEdge *QGVScene::addEdge(QGVNode *source, QGVNode *target, const QString &label)
 {
-		Agedge_t* edge = agedge(_graph->graph(), source->_node->node(), target->_node->node(), NULL, TRUE);
+    Agedge_t* edge = agedge(_graph->graph(), source->_node->node(), target->_node->node(), NULL, TRUE);
     if(edge == NULL)
     {
         qWarning()<<"Invalid egde :"<<label;
         return 0;
     }
 
-		QGVEdge *item = new QGVEdge(new QGVEdgePrivate(edge), this);
+    QGVEdge *item = new QGVEdge(new QGVEdgePrivate(edge), this);
     item->setLabel(label);
     addItem(item);
     _edges.append(item);
@@ -96,9 +97,9 @@ QGVSubGraph *QGVScene::addSubGraph(const QString &name, bool cluster)
 {
     Agraph_t* sgraph;
     if(cluster)
-				sgraph = agsubg(_graph->graph(), ("cluster_" + name).toLocal8Bit().data(), TRUE);
+        sgraph = agsubg(_graph->graph(), ("cluster_" + name).toLocal8Bit().data(), TRUE);
     else
-				sgraph = agsubg(_graph->graph(), name.toLocal8Bit().data(), TRUE);
+        sgraph = agsubg(_graph->graph(), name.toLocal8Bit().data(), TRUE);
 
     if(sgraph == NULL)
     {
@@ -106,7 +107,7 @@ QGVSubGraph *QGVScene::addSubGraph(const QString &name, bool cluster)
         return 0;
     }
 
-		QGVSubGraph *item = new QGVSubGraph(new QGVGraphPrivate(sgraph), this);
+    QGVSubGraph *item = new QGVSubGraph(new QGVGraphPrivate(sgraph), this);
     addItem(item);
     _subGraphs.append(item);
     return item;
@@ -115,31 +116,31 @@ QGVSubGraph *QGVScene::addSubGraph(const QString &name, bool cluster)
 void QGVScene::setRootNode(QGVNode *node)
 {
     Q_ASSERT(_nodes.contains(node));
-		agset(_graph->graph(), "root", node->label().toLocal8Bit().data());
+    agset(_graph->graph(), "root", node->label().toLocal8Bit().data());
 }
 
 void QGVScene::loadLayout(const QString &text)
 {
-		_graph->setGraph(QGVCore::agmemread2(text.toLocal8Bit().constData()));
+    _graph->setGraph(QGVCore::agmemread2(text.toLocal8Bit().constData()));
 
-		if(gvLayout(_context->context(), _graph->graph(), "dot") != 0)
+    if(gvLayout(_context->context(), _graph->graph(), "dot") != 0)
     {
         qCritical()<<"Layout render error"<<agerrors()<<QString::fromLocal8Bit(aglasterr());
         return;
     }
 
     //Debug output
-		//gvRenderFilename(_context->context(), _graph->graph(), "png", "debug.png");
+    //gvRenderFilename(_context->context(), _graph->graph(), "png", "debug.png");
 
     //Read nodes and edges
-		for (Agnode_t* node = agfstnode(_graph->graph()); node != NULL; node = agnxtnode(_graph->graph(), node))
+    for (Agnode_t* node = agfstnode(_graph->graph()); node != NULL; node = agnxtnode(_graph->graph(), node))
     {
-				QGVNode *inode = new QGVNode(new QGVNodePrivate(node), this);
+    QGVNode *inode = new QGVNode(new QGVNodePrivate(node), this);
         inode->updateLayout();
         addItem(inode);
-				for (Agedge_t* edge = agfstout(_graph->graph(), node); edge != NULL; edge = agnxtout(_graph->graph(), edge))
+    for (Agedge_t* edge = agfstout(_graph->graph(), node); edge != NULL; edge = agnxtout(_graph->graph(), edge))
         {
-						QGVEdge *iedge = new QGVEdge(new QGVEdgePrivate(edge), this);
+    QGVEdge *iedge = new QGVEdge(new QGVEdgePrivate(edge), this);
             iedge->updateLayout();
             addItem(iedge);
         }
@@ -162,8 +163,8 @@ void QGVScene::applyLayout()
     }
 
     //Debug output
-		//gvRenderFilename(_context->context(), _graph->graph(), "canon", "debug.dot");
-		//gvRenderFilename(_context->context(), _graph->graph(), "png", "debug.png");
+    //gvRenderFilename(_context->context(), _graph->graph(), "canon", "debug.dot");
+    //gvRenderFilename(_context->context(), _graph->graph(), "png", "debug.png");
 
     //Update items layout
     foreach(QGVNode* node, _nodes)
@@ -176,11 +177,11 @@ void QGVScene::applyLayout()
         sgraph->updateLayout();
 
     //Graph label
-		textlabel_t *xlabel = GD_label(_graph->graph());
+    textlabel_t *xlabel = GD_label(_graph->graph());
     if(xlabel)
     {
         QGraphicsTextItem *item = addText(xlabel->text);
-				item->setPos(QGVCore::centerToOrigin(QGVCore::toPoint(xlabel->pos, QGVCore::graphHeight(_graph->graph())), xlabel->dimen.x, -4));
+        item->setPos(QGVCore::centerToOrigin(QGVCore::toPoint(xlabel->pos, QGVCore::graphHeight(_graph->graph())), xlabel->dimen.x, -4));
     }
 
     update();
@@ -195,7 +196,6 @@ void QGVScene::clear()
     QGraphicsScene::clear();
 }
 
-#include <QGraphicsSceneContextMenuEvent>
 void QGVScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *contextMenuEvent)
 {
     QGraphicsItem *item = itemAt(contextMenuEvent->scenePos(), QTransform());

--- a/QGVCore/QGVSubGraph.cpp
+++ b/QGVCore/QGVSubGraph.cpp
@@ -32,25 +32,25 @@ QGVSubGraph::QGVSubGraph(QGVGraphPrivate *subGraph, QGVScene *scene): _sgraph(su
 QGVSubGraph::~QGVSubGraph()
 {
     _scene->removeItem(this);
-		delete _sgraph;
+    delete _sgraph;
 }
 
 QString QGVSubGraph::name() const
 {
-		return QString::fromLocal8Bit(GD_label(_sgraph->graph())->text);
+    return QString::fromLocal8Bit(GD_label(_sgraph->graph())->text);
 }
 
 QGVNode *QGVSubGraph::addNode(const QString &label)
 {
-		Agnode_t *node = agnode(_sgraph->graph(), NULL, TRUE);
+    Agnode_t *node = agnode(_sgraph->graph(), NULL, TRUE);
     if(node == NULL)
     {
         qWarning()<<"Invalid sub node :"<<label;
         return 0;
     }
-		agsubnode(_sgraph->graph(), node, TRUE);
+    agsubnode(_sgraph->graph(), node, TRUE);
 
-		QGVNode *item = new QGVNode(new QGVNodePrivate(node), _scene);
+    QGVNode *item = new QGVNode(new QGVNodePrivate(node), _scene);
     item->setLabel(label);
     _scene->addItem(item);
     _scene->_nodes.append(item);
@@ -62,9 +62,9 @@ QGVSubGraph *QGVSubGraph::addSubGraph(const QString &name, bool cluster)
 {
     Agraph_t* sgraph;
     if(cluster)
-				sgraph = agsubg(_sgraph->graph(), ("cluster_" + name).toLocal8Bit().data(), TRUE);
+        sgraph = agsubg(_sgraph->graph(), ("cluster_" + name).toLocal8Bit().data(), TRUE);
     else
-				sgraph = agsubg(_sgraph->graph(), name.toLocal8Bit().data(), TRUE);
+        sgraph = agsubg(_sgraph->graph(), name.toLocal8Bit().data(), TRUE);
 
     if(sgraph == NULL)
     {
@@ -72,7 +72,7 @@ QGVSubGraph *QGVSubGraph::addSubGraph(const QString &name, bool cluster)
         return 0;
     }
 
-		QGVSubGraph *item = new QGVSubGraph(new QGVGraphPrivate(sgraph), _scene);
+    QGVSubGraph *item = new QGVSubGraph(new QGVGraphPrivate(sgraph), _scene);
     _scene->_subGraphs.append(item);
     _scene->addItem(item);
     return item;
@@ -122,12 +122,12 @@ void QGVSubGraph::paint(QPainter * painter, const QStyleOptionGraphicsItem * opt
 
 void QGVSubGraph::setAttribute(const QString &name, const QString &value)
 {
-		agsafeset(_sgraph->graph(), name.toLocal8Bit().data(), value.toLocal8Bit().data(), "");
+    agsafeset(_sgraph->graph(), name.toLocal8Bit().data(), value.toLocal8Bit().data(), "");
 }
 
 QString QGVSubGraph::getAttribute(const QString &name) const
 {
-		char* value = agget(_sgraph->graph(), name.toLocal8Bit().data());
+    char* value = agget(_sgraph->graph(), name.toLocal8Bit().data());
     if(value)
         return value;
     return QString();

--- a/QGVCore/QGVSubGraph.h
+++ b/QGVCore/QGVSubGraph.h
@@ -46,6 +46,10 @@ public:
     void setAttribute(const QString &name, const QString &value);
     QString getAttribute(const QString &name) const;
     void updateLayout();
+    void setIcon(const QImage &icon);
+    void setVertex(void* v);
+    void* getVertex();
+    QString label() const;
 
     enum { Type = UserType + 4 };
     int type() const
@@ -56,7 +60,7 @@ public:
 
 private:
     friend class QGVScene;
-		QGVSubGraph(QGVGraphPrivate* subGraph, QGVScene *scene);
+    QGVSubGraph(QGVGraphPrivate* subGraph, QGVScene *scene);
 
     double _height, _width;
     QPen _pen;
@@ -64,9 +68,11 @@ private:
 
     QString _label;
     QRectF _label_rect;
+    QImage _icon;
 
     QGVScene *_scene;
-		QGVGraphPrivate *_sgraph;
+    QGVGraphPrivate *_sgraph;
+    void* vertex;
     QList<QGVNode*> _nodes;
 };
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -84,8 +84,10 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->actionProfilePortsRate->setEnabled(false);
     moduleParentItem = new QTreeWidgetItem( ui->nodesTreeWidget,  QStringList("Modules"));
     portParentItem = new QTreeWidgetItem( ui->nodesTreeWidget,  QStringList("Ports"));
+    machinesParentItem = new QTreeWidgetItem( ui->nodesTreeWidget,  QStringList("Machines"));
     moduleParentItem->setIcon(0, QIcon(":icons/resources/module.svg"));
     portParentItem->setIcon(0, QIcon(":icons/resources/port.svg"));
+    machinesParentItem->setIcon(0, QIcon(":icons/resources/computer_B.svg"));
 
 }
 
@@ -100,6 +102,8 @@ void MainWindow::initScene() {
         delete scene;
     }
     scene = new QGVScene("yarpviz", this);
+    sceneNodeMap.clear();
+    sceneSubGraphMap.clear();
     ui->graphicsView->setBackgroundBrush(QBrush(QColor("#2e3e56"), Qt::SolidPattern));
     ui->graphicsView->setScene(scene);
     connect(scene, SIGNAL(nodeContextMenu(QGVNode*)), SLOT(nodeContextMenu(QGVNode*)));
@@ -138,54 +142,74 @@ void MainWindow::drawGraph(Graph &graph)
     // drawing nodes
     // create a map between graph nodes and their visualization
     //std::map<const Vertex*, QGVNode*> nodeSet;
-    std::map<const string, QGVSubGraph*> subgraphSet;
 
 
     // adding all process nodes and subgraphs
     pvertex_const_iterator itr;
     const pvertex_set& vertices = graph.vertices();
+    int countChild =0;
     for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
         dynamic_cast<YarpvizVertex*>(*itr)->setGraphicItem(NULL);
         const Property& prop = (*itr)->property;
-        QGVNode *node;
+        QGVSubGraph *sgraph;
         if(dynamic_cast<ProcessVertex*>(*itr) && !prop.check("hidden"))
         {
+            string name =  prop.find("name").asString() + countChild;
             if(layoutSubgraph) {
-                QGVSubGraph *sgraph = scene->addSubGraph(prop.toString().c_str());
-                //sgraph->setAttribute("label", prop.find("name").asString().c_str());
-                sgraph->setAttribute("color", "#2e3e56"); // hidden!
-                //sgraph->setAttribute("fillcolor", "#0180B5");
                 std::stringstream key;
-                key<<prop.find("host").asString()<<prop.find("name").asString()<<prop.find("pid").asInt();
-                subgraphSet[key.str()] = sgraph;
-                node = sgraph->addNode(prop.find("name").asString().c_str());
-            }else
-                node = scene->addNode(prop.find("name").asString().c_str());
+                key<<prop.find("hostname").asString();
+                QGVSubGraph *sgraphParent;
+                if(sceneSubGraphMap[key.str()] == NULL)
+                {
+                    sgraphParent = scene->addSubGraph(prop.toString().c_str());
+                    sceneSubGraphMap[key.str()] = sgraphParent;
+                }
+                else
+                {
+                    sgraphParent = sceneSubGraphMap[key.str()];
+                }
+                if(sgraphParent == NULL)
+                    cout<<"AAAAAAAAAAAAAAAAAAAAAAAAAAAAA"<<endl;
+                //sgraph->setAttribute("label", prop.find("name").asString().c_str());
+                sgraphParent->setAttribute("color", "#FFFFFF");
+                sgraphParent->setAttribute("label", prop.find("hostname").toString().c_str());
+                string host = prop.find("os").asString();
+                if(host == "Linux")
+                    sgraphParent->setIcon(QImage(":/icons/resources/Linux-icon.png"));
+                else if(host == "Windows")
+                    sgraphParent->setIcon(QImage(":/icons/resources/Windows-icon.png"));
+                else if(host == "Mac")
+                    sgraphParent->setIcon(QImage(":/icons/resources/Mac-icon.png"));
+                else
+                    sgraphParent->setIcon(QImage(":/icons/resources/Gnome-System-Run-64.png"));
+                //sgraph->setAttribute("fillcolor", "#0180B5");
+                sgraph = sgraphParent->addSubGraph(name.c_str());
+                countChild++;
+            }
+            else
+            {
+                sgraph = scene->addSubGraph(name.c_str());
+                countChild++;
+            }
 
             std::stringstream label;
             label << "   " << prop.find("name").asString().c_str()
                   << " (" << prop.find("pid").asInt() << ")   ";
-            node->setAttribute("shape", "box");
-            node->setAttribute("label", label.str().c_str());
+            sgraph->setAttribute("shape", "box");
+            sgraph->setAttribute("label", label.str().c_str());
             if(prop.check("color")) {
-                node->setAttribute("fillcolor", prop.find("color").asString().c_str());
-                node->setAttribute("color", prop.find("color").asString().c_str());
+                sgraph->setAttribute("fillcolor", prop.find("color").asString().c_str());
+                sgraph->setAttribute("color", prop.find("color").asString().c_str());
             }else {
-                node->setAttribute("fillcolor", "#a5cf80");
-                node->setAttribute("color", "#a5cf80");
+                sgraph->setAttribute("fillcolor", "#a5cf80");
+                sgraph->setAttribute("color", "#a5cf80");
             }
-            string host = prop.find("os").asString();
-            if(host == "Linux")
-                node->setIcon(QImage(":/icons/resources/Linux-icon.png"));
-            else if(host == "Windows")
-                node->setIcon(QImage(":/icons/resources/Windows-icon.png"));
-            else if(host == "Mac")
-                node->setIcon(QImage(":/icons/resources/Mac-icon.png"));
-            else
-                node->setIcon(QImage(":/icons/resources/Gnome-System-Run-64.png"));
             //nodeSet[*itr] = node;
-            dynamic_cast<YarpvizVertex*>(*itr)->setGraphicItem(node);
-            node->setVertex(*itr);
+            dynamic_cast<YarpvizVertex*>(*itr)->setGraphicItem(sgraph);
+            sgraph->setVertex(*itr);
+            std::stringstream keyProcess;
+            keyProcess<<prop.find("hostname").asString()<<prop.find("pid").asInt();
+            sceneSubGraphMap[keyProcess.str()]= sgraph;
         }
     }
 
@@ -195,17 +219,17 @@ void MainWindow::drawGraph(Graph &graph)
     int portCounts = 0;
     for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
         const Property& prop = (*itr)->property;
-        if(dynamic_cast<PortVertex*>(*itr) && !prop.check("hidden")) {
+        if(dynamic_cast<PortVertex*>(*itr) && !prop.check("hidden") ) {
             if(!prop.check("orphan")) {
                 QGVNode *node;
                 if(layoutSubgraph) {
                     PortVertex* pv = dynamic_cast<PortVertex*>(*itr);
                     ProcessVertex* v = (ProcessVertex*) pv->getOwner();
                     std::stringstream key;
-                    key<<v->property.find("host").asString()<<v->property.find("name").asString()<<v->property.find("pid").asInt();
-                    QGVSubGraph *sgraph = subgraphSet[key.str()];
+                    key<<v->property.find("hostname").asString()<<v->property.find("pid").asInt();
+                    QGVSubGraph *sgraph = sceneSubGraphMap[key.str()];
                     if(sgraph)
-                        node =  sgraph->addNode(prop.find("name").asString().c_str());                    
+                        node =  sgraph->addNode(prop.find("name").asString().c_str());
                     else
                         node =  scene->addNode(prop.find("name").asString().c_str());
                 }
@@ -243,11 +267,7 @@ void MainWindow::drawGraph(Graph &graph)
             if(!v1.property.check("hidden") && !v2.property.check("hidden")) {
                 if(edge.property.find("type").asString() == "ownership" &&
                         edge.property.find("dir").asString() != "unknown") {
-                    //QGVEdge* gve = scene->addEdge(nodeSet[&v1], nodeSet[&v2], "");
-                    QGVEdge* gve = scene->addEdge((QGVNode*)((YarpvizVertex*)&v1)->getGraphicItem(),
-                                                  (QGVNode*)((YarpvizVertex*)&v2)->getGraphicItem(), "");
-                    gve->setAttribute("color", "grey");
-                    gve->setAttribute("style", "dashed");
+                    continue;
                 }
 
                 if(edge.property.find("type").asString() == "connection") {                    
@@ -449,6 +469,10 @@ void MainWindow::onProfileYarpNetwork() {
         item = portParentItem->child(i);
         delete item;
     }
+    for (int i= machinesParentItem->childCount()-1; i>-1; i--) {
+        item = machinesParentItem->child(i);
+        delete item;
+    }
     pvertex_const_iterator itr;
     const pvertex_set& vertices = mainGraph.vertices();
     for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
@@ -470,6 +494,7 @@ void MainWindow::onProfileYarpNetwork() {
     NetworkProfiler::updateConnectionQosStatus(mainGraph);
     moduleParentItem->setExpanded(true);
     portParentItem->setExpanded(true);
+    machinesParentItem->setExpanded(true);
     currentGraph = &mainGraph;
     drawGraph(*currentGraph);
     ui->actionHighlight_Loops->setEnabled(true);
@@ -514,6 +539,11 @@ void MainWindow::updateNodeWidgetItems() {
     }
     for (int i= portParentItem->childCount()-1; i>-1; i--) {
         item = (NodeWidgetItem*) portParentItem->child(i);
+        yAssert(item != NULL);
+        item->check(!item->getVertex()->property.check("hidden"));
+    }
+    for (int i= machinesParentItem->childCount()-1; i>-1; i--) {
+        item = (NodeWidgetItem*) machinesParentItem->child(i);
         yAssert(item != NULL);
         item->check(!item->getVertex()->property.check("hidden"));
     }
@@ -571,6 +601,10 @@ void MainWindow::onHidePorts() {
         item = portParentItem->child(i);
         delete item;
     }
+    for (int i= machinesParentItem->childCount()-1; i>-1; i--) {
+        item = machinesParentItem->child(i);
+        delete item;
+    }
 
     if(ui->actionHidePorts->isChecked()) {
         NetworkProfiler::creatSimpleModuleGraph(mainGraph, simpleGraph);
@@ -605,6 +639,7 @@ void MainWindow::onHidePorts() {
         }
         moduleParentItem->setExpanded(true);
         portParentItem->setExpanded(true);
+        machinesParentItem->setExpanded(true);
         currentGraph = &mainGraph;
     }
     drawGraph(*currentGraph);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -317,6 +317,9 @@ void MainWindow::drawGraph(Graph &graph)
         for(int i=0; i<v1.outEdges().size(); i++) {
             const Edge& edge = v1.outEdges()[i];
             const Vertex &v2 = edge.second();
+            string targetName = v2.property.find("name").asString();
+            if(!ui->actionDebugMode->isChecked() && targetName.find("/yarplogger") != string::npos)
+                continue;
             //yInfo()<<"Drawing:"<<v1.property.find("name").asString()<<" -> "<<v2.property.find("name").asString();
             // add ownership edges
             if(!v1.property.find("hidden").asBool() && !v2.property.find("hidden").asBool()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -66,6 +66,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionConfigure_connections_QOS, SIGNAL(triggered()),this,SLOT(onConfigureConsQos()));
     connect(ui->actionUpdateConnectionQosStatus, SIGNAL(triggered()),this,SLOT(onUpdateQosStatus()));
     connect(ui->actionProfilePortsRate, SIGNAL(triggered()),this,SLOT(onProfilePortsRate()));
+    connect(ui->actionAbout, SIGNAL(triggered()),this,SLOT(onAbout()));
 
     //progressDlg = new QProgressDialog("...", "Cancel", 0, 100, this);
 
@@ -438,6 +439,11 @@ void MainWindow::onSubGraphContextMenuProcess(QGVSubGraph *sgraph) {
         updateNodeWidgetItems();
         drawGraph(*currentGraph);
     }
+}
+
+void MainWindow::onAbout() {
+    QMessageBox::about(this, "yarpviz (version 2.0.0)",
+                       "A graphical tool for a graphical tool for profiling and visualizing Yarp network!\n\nAuthors:\n\t-Ali Paikan <ali.paikan@iit.it>\n\t-Nicolò Genesio <nicolo.genesio@iit.it>");
 }
 
 void MainWindow::onNodeContextMenuPort(QGVNode *node, YarpvizVertex* vertex) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -269,7 +269,7 @@ void MainWindow::drawGraph(Graph &graph)
             ProcessVertex* v = (ProcessVertex*) pv->getOwner();
             if(ui->actionHideDisconnectedPorts->isChecked() && pv->property.find("orphan").asBool())
                 continue;
-            if(!ui->actionDebugMode->isChecked() && portName.find("/log") != string::npos)
+            if(!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos ))
                 continue;
             std::stringstream key;
             if(v->property.find("hidden").asBool())
@@ -603,15 +603,23 @@ void MainWindow::populateTreeWidget(){
     for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
         const Property& prop = (*itr)->property;
         if(dynamic_cast<ProcessVertex*>(*itr)) {
+            string processName = prop.find("name").asString();
+            if(!ui->actionDebugMode->isChecked() && processName.find("yarplogger") != string::npos)
+            {
+                continue;
+            }
             NodeWidgetItem *moduleItem =  new NodeWidgetItem(moduleParentItem, (*itr), MODULE);
             moduleItem->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
             moduleItem->check(true);
         }
         else if(dynamic_cast<PortVertex*>(*itr) && !ui->actionHidePorts->isChecked()) {
+            string portName = prop.find("name").asString();
             if(ui->actionHideDisconnectedPorts->isChecked()){
-                if((*itr)->property.check("orphan"))
+                if(prop.check("orphan"))
                     continue;
             }
+            if(!ui->actionDebugMode->isChecked() && (portName.find("/log") != string::npos || portName.find("/yarplogger") != string::npos ))
+                continue;
             NodeWidgetItem *portItem =  new NodeWidgetItem(portParentItem, (*itr), PORT);
             portItem->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable );
             portItem->check(true);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -74,6 +74,7 @@ private:
     void initScene();
     void onNodeContextMenuPort(QGVNode *node, YarpvizVertex* vertex);
     void updateNodeWidgetItems();
+    void populateTreeWidget();
 
 private slots:
     void nodeContextMenu(QGVNode* node);
@@ -85,9 +86,8 @@ private slots:
     void onLayoutPolyline();
     void onLayoutLine();
     void onLayoutCurved();
-    void onLayoutSubgraph();
     void onHidePorts();
-    void onHideConnectionsLable();
+    void onUpdateGraph();
     void onNodesTreeItemClicked(QTreeWidgetItem *item, int column);
     void onWindowMessageBox();
     void onWindowItem();
@@ -96,7 +96,7 @@ private slots:
     void onUpdateQosStatus();
     void onConfigureConsQos();
     void onProfilePortsRate();
-    void onSubGraphContextMenuProccess(QGVSubGraph *node);
+    void onSubGraphContextMenuProcess(QGVSubGraph *node);
 
 private:
     Ui::MainWindow *ui;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -19,7 +19,8 @@
 
 enum NodeItemType { UNKNOWN = 0,
                     MODULE = 1,
-                    PORT = 2 };
+                    PORT = 2,
+                    MACHINE = 3};
 
 
 class NodeWidgetItem : public QTreeWidgetItem {
@@ -31,6 +32,13 @@ public:
             std::stringstream lable;
             lable << vertex->property.find("name").asString().c_str()
                   << " (" << vertex->property.find("pid").asInt() << ")";
+            setText(0, lable.str().c_str());
+        }
+        else if(dynamic_cast<MachineVertex*> (vertex))
+        {
+            std::stringstream lable;
+            lable << vertex->property.find("hostname").asString().c_str()
+                  << " (" << vertex->property.find("os").asString() << ")";
             setText(0, lable.str().c_str());
         }
         checkFlag = false;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -94,7 +94,6 @@ private slots:
     void onLayoutPolyline();
     void onLayoutLine();
     void onLayoutCurved();
-    void onHidePorts();
     void onUpdateGraph();
     void onNodesTreeItemClicked(QTreeWidgetItem *item, int column);
     void onWindowMessageBox();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -104,6 +104,7 @@ private slots:
     void onConfigureConsQos();
     void onProfilePortsRate();
     void onSubGraphContextMenuProcess(QGVSubGraph *node);
+    void onAbout();
 
 private:
     Ui::MainWindow *ui;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -43,7 +43,7 @@ public:
         if(!checkFlag)
             vertex->property.put("hidden", true);
         else
-            vertex->property.unput("hidden");
+            vertex->property.put("hidden",false);
     }
 
     bool checked() { return checkFlag; }
@@ -72,7 +72,6 @@ public:
 
 private:
     void initScene();
-    void onNodeContextMenuProccess(QGVNode *node, YarpvizVertex* vertex);
     void onNodeContextMenuPort(QGVNode *node, YarpvizVertex* vertex);
     void updateNodeWidgetItems();
 
@@ -97,6 +96,7 @@ private slots:
     void onUpdateQosStatus();
     void onConfigureConsQos();
     void onProfilePortsRate();
+    void onSubGraphContextMenuProccess(QGVSubGraph *node);
 
 private:
     Ui::MainWindow *ui;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -111,6 +111,9 @@ private:
     bool layoutSubgraph;
     QTreeWidgetItem *moduleParentItem;
     QTreeWidgetItem *portParentItem;
+    QTreeWidgetItem *machinesParentItem;
+    std::map<std::string, QGVSubGraph*> sceneSubGraphMap;
+    std::map<std::string, QGVNode*> sceneNodeMap;
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -152,6 +152,7 @@
     <addaction name="actionHidePorts"/>
     <addaction name="actionHideConnectionsLable"/>
     <addaction name="actionHideDisconnectedPorts"/>
+    <addaction name="actionDebugMode"/>
    </widget>
    <widget class="QMenu" name="menuView_2">
     <property name="title">
@@ -182,6 +183,7 @@
    </attribute>
    <addaction name="actionProfile_YARP_network"/>
    <addaction name="separator"/>
+   <addaction name="actionDebugMode"/>
    <addaction name="actionHidePorts"/>
    <addaction name="actionHighlight_Loops"/>
   </widget>
@@ -350,6 +352,21 @@
    </property>
    <property name="text">
     <string>Hide Disconnected Ports</string>
+   </property>
+  </action>
+  <action name="actionDebugMode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="ress.qrc">
+     <normaloff>:/icons/resources/debugMode.svg</normaloff>:/icons/resources/debugMode.svg</iconset>
+   </property>
+   <property name="text">
+    <string>DebugMode</string>
+   </property>
+   <property name="toolTip">
+    <string>Check it to show yarplogger and &quot;/log&quot; ports</string>
    </property>
   </action>
  </widget>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -98,7 +98,7 @@
      <x>0</x>
      <y>0</y>
      <width>817</width>
-     <height>21</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -151,6 +151,7 @@
     <addaction name="separator"/>
     <addaction name="actionHidePorts"/>
     <addaction name="actionHideConnectionsLable"/>
+    <addaction name="actionHideDisconnectedPorts"/>
    </widget>
    <widget class="QMenu" name="menuView_2">
     <property name="title">
@@ -341,6 +342,14 @@
   <action name="actionConfigure_connections_QOS">
    <property name="text">
     <string>&amp;Configure connections QOS...</string>
+   </property>
+  </action>
+  <action name="actionHideDisconnectedPorts">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Hide Disconnected Ports</string>
    </property>
   </action>
  </widget>

--- a/src/NetworkProfiler.cpp
+++ b/src/NetworkProfiler.cpp
@@ -144,7 +144,6 @@ bool NetworkProfiler::creatNetworkGraph(ports_detail_set details, yarp::graph::G
     unsigned int itr_count = 0;
     for(itr = details.begin(); itr!=details.end(); itr++) {
         PortDetails info = (*itr);
-        std::cout<<graph.size()<<std::endl;
 
         // port node
         PortVertex* port = new PortVertex(info.name);
@@ -159,7 +158,6 @@ bool NetworkProfiler::creatNetworkGraph(ports_detail_set details, yarp::graph::G
         process->property.put("priority", info.owner.priority);
         process->property.put("policy", info.owner.policy);
         process->property.put("os", info.owner.os);
-        std::cout<<process->property.toString()<<std::endl;
         graph.insert(*process);
 
         // create connection between ports and its owner
@@ -167,7 +165,6 @@ bool NetworkProfiler::creatNetworkGraph(ports_detail_set details, yarp::graph::G
 
         //machine node (owner of the process)
         MachineVertex* machine = new MachineVertex(info.owner.os, info.owner.hostname);
-        std::cout<<machine->property.toString()<<std::endl;
         graph.insert(*machine);
         process->setOwner(machine);
 
@@ -246,6 +243,22 @@ bool NetworkProfiler::creatSimpleModuleGraph(yarp::graph::Graph& graph, yarp::gr
     subgraph.clear();
     pvertex_const_iterator itr;
     const pvertex_set& vertices = graph.vertices();
+    //insert machines
+    for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
+
+        if(!dynamic_cast<MachineVertex*>(*itr))
+                continue;
+        else
+        {
+            MachineVertex* mv1 = dynamic_cast<MachineVertex*>(*itr);
+            MachineVertex* mv2 = new MachineVertex(mv1->property.find("os").asString(),
+                                                   mv1->property.find("hostname").asString());
+            mv2->property = mv1->property;
+
+            subgraph.insert(*mv2);
+        }
+    }
+
     for(itr = vertices.begin(); itr!=vertices.end(); itr++) {
         if(!dynamic_cast<ProcessVertex*>(*itr))
             continue;

--- a/src/NetworkProfiler.cpp
+++ b/src/NetworkProfiler.cpp
@@ -147,6 +147,8 @@ bool NetworkProfiler::creatNetworkGraph(ports_detail_set details, yarp::graph::G
 
         // port node
         PortVertex* port = new PortVertex(info.name);
+        if(!info.inputs.size() && !info.outputs.size())
+            port->property.put("orphan", true);
         graph.insert(*port);
 
         //process node (owner)

--- a/src/NetworkProfiler.cpp
+++ b/src/NetworkProfiler.cpp
@@ -160,14 +160,18 @@ bool NetworkProfiler::creatNetworkGraph(ports_detail_set details, yarp::graph::G
         process->property.put("priority", info.owner.priority);
         process->property.put("policy", info.owner.policy);
         process->property.put("os", info.owner.os);
-        graph.insert(*process);
+        process->property.put("hidden", false);
+        pvertex_iterator itrVert=graph.insert(*process);
+        // create connection between ports and its process
+        if(dynamic_cast<ProcessVertex*> (*itrVert))
+            port->setOwner((ProcessVertex*)(*itrVert));
 
-        // create connection between ports and its owner
-        port->setOwner(process);
+
 
         //machine node (owner of the process)
         MachineVertex* machine = new MachineVertex(info.owner.os, info.owner.hostname);
         graph.insert(*machine);
+        //todo do the same done for the process.
         process->setOwner(machine);
 
         if(!info.inputs.size() && !info.outputs.size())

--- a/src/NetworkProfiler.h
+++ b/src/NetworkProfiler.h
@@ -49,27 +49,33 @@ private:
 
 class ProcessVertex : public YarpvizVertex{
 public:
-        ProcessVertex(int pid, const std::string hostname) : YarpvizVertex("(type process)") {
+        ProcessVertex(int pid, const std::string hostname) : YarpvizVertex("(type process)"), owner(NULL) {
             property.put("hostname", hostname);
             property.put("pid", pid);
         }
+        void setOwner(yarp::graph::Vertex* owner) { ProcessVertex::owner = owner; }
+        yarp::graph::Vertex* getOwner() { return owner; }
 
         virtual bool operator == (const yarp::graph::Vertex &v1) const {
             return property.find("hostname").asString() == v1.property.find("hostname").asString() &&
                    property.find("pid").asInt() == v1.property.find("pid").asInt();
         }
+
+private:
+        yarp::graph::Vertex* owner;
 };
 
 class MachineVertex : public YarpvizVertex{
 public:
-        MachineVertex(std::string os, const std::string hostname) : YarpvizVertex("(type process)") {
+        MachineVertex(std::string os, const std::string hostname) : YarpvizVertex("(type machine)") {
             property.put("hostname", hostname);
             property.put("os", os);
         }
 
         virtual bool operator == (const yarp::graph::Vertex &v1) const {
             return property.find("hostname").asString() == v1.property.find("hostname").asString() &&
-                   property.find("os").asString() == v1.property.find("os").asString();
+                   property.find("os").asString() == v1.property.find("os").asString() &&
+                   property.find("type").asString() == v1.property.find("type").asString() ;
         }
 };
 
@@ -86,18 +92,22 @@ public:
         std::string name;
         std::string carrier;
     };
+    struct MachineInfo {
+        std::string os;
+        std::string hostname;
 
+    };
     struct ProcessInfo {
         std::string name;
         std::string arguments;
         std::string os;
         std::string hostname;
+        MachineInfo owner;
         int pid;
         int priority;
         int policy;
         ProcessInfo() { pid = priority = policy = -1; }
     };
-
     struct PortDetails {
         std::string name;
         std::vector<ConnectionInfo> outputs;

--- a/src/NetworkProfiler.h
+++ b/src/NetworkProfiler.h
@@ -47,7 +47,6 @@ private:
     yarp::graph::Vertex* owner;
 };
 
-
 class ProcessVertex : public YarpvizVertex{
 public:
         ProcessVertex(int pid, const std::string hostname) : YarpvizVertex("(type process)") {
@@ -61,7 +60,18 @@ public:
         }
 };
 
+class MachineVertex : public YarpvizVertex{
+public:
+        MachineVertex(std::string os, const std::string hostname) : YarpvizVertex("(type process)") {
+            property.put("hostname", hostname);
+            property.put("os", os);
+        }
 
+        virtual bool operator == (const yarp::graph::Vertex &v1) const {
+            return property.find("hostname").asString() == v1.property.find("hostname").asString() &&
+                   property.find("os").asString() == v1.property.find("os").asString();
+        }
+};
 
 class NetworkProfiler {
 

--- a/src/ggraph.cpp
+++ b/src/ggraph.cpp
@@ -120,14 +120,10 @@ void Graph::insert(Vertex *vertex) {
 }
 */
 
-#include<stdio.h>
+
 void Graph::insert(const Vertex &vertex){
-    if( find(vertex) != mVertices.end()){
-        std::cout<<"C E' GIA'"<<std::endl;
-        return;
-    }
+    if( find(vertex) != mVertices.end()) return;
    // Vertex* v = new Vertex(vertex);
-    std::cout<<"INSERITO"<<std::endl;
     mVertices.push_back((Vertex*) &vertex);
 }
 

--- a/src/ggraph.cpp
+++ b/src/ggraph.cpp
@@ -120,10 +120,14 @@ void Graph::insert(Vertex *vertex) {
 }
 */
 
-
+#include<stdio.h>
 void Graph::insert(const Vertex &vertex){
-    if( find(vertex) != mVertices.end()) return;
+    if( find(vertex) != mVertices.end()){
+        std::cout<<"C E' GIA'"<<std::endl;
+        return;
+    }
    // Vertex* v = new Vertex(vertex);
+    std::cout<<"INSERITO"<<std::endl;
     mVertices.push_back((Vertex*) &vertex);
 }
 

--- a/src/ggraph.cpp
+++ b/src/ggraph.cpp
@@ -121,10 +121,12 @@ void Graph::insert(Vertex *vertex) {
 */
 
 
-void Graph::insert(const Vertex &vertex){
-    if( find(vertex) != mVertices.end()) return;
+pvertex_iterator Graph::insert(const Vertex &vertex){
+    pvertex_iterator itr = find(vertex);
+    if( itr != mVertices.end()) return itr;
    // Vertex* v = new Vertex(vertex);
     mVertices.push_back((Vertex*) &vertex);
+    return mVertices.end()-1;
 }
 
 

--- a/src/ggraph.h
+++ b/src/ggraph.h
@@ -108,7 +108,7 @@ public:
     virtual ~Graph();
 
     //void insert(Vertex *vertex);
-    void insert(const Vertex &vertex);
+    pvertex_iterator insert(const Vertex &vertex);
     void remove(const Vertex &vertex);
     void remove(const pvertex_iterator vi);
 

--- a/src/resources/computer_B.svg
+++ b/src/resources/computer_B.svg
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="512"
+   height="512"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="computer.svg"
+   inkscape:export-filename="/home/alecive/Scrivania/firefoxTest1.png"
+   inkscape:export-xdpi="100"
+   inkscape:export-ydpi="100">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.27982011"
+     inkscape:cx="299"
+     inkscape:cy="213"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="false"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-nodes="true" />
+  <defs
+     id="defs4">
+    <linearGradient
+       x1="19.244999"
+       y1="21.030804"
+       x2="19.360001"
+       gradientUnits="userSpaceOnUse"
+       y2="44.984001"
+       id="linearGradient2460">
+      <stop
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4114-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0317796,0,0,1.0317796,-830.86406,592.67791)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow-0-1-1-5-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0058652,0,0,0.994169,100,0)">
+      <stop
+         id="stop3750-8-9-3-6-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-5-6-4-2-9"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4112-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0402541,0,0,1.0402541,-837.95116,592.51825)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4110-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.023305,0,0,1.023305,-823.77704,592.83757)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4116-6-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0148305,0,0,1.0148305,-816.68996,592.99723)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       y2="20.625916"
+       x2="1006.8082"
+       y1="484.41721"
+       x1="1012.5133"
+       gradientTransform="matrix(1.0074153,0,0,1.0074153,-810.48879,593.1369)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5342-3"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3737-9"
+       id="linearGradient4084-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(778.59979,-360.55963)"
+       x1="993.43896"
+       y1="51.511765"
+       x2="988.78552"
+       y2="363.73825" />
+    <linearGradient
+       id="linearGradient3737-9">
+      <stop
+         id="stop3739-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4046-3"
+       id="linearGradient4086-12"
+       gradientUnits="userSpaceOnUse"
+       x1="1764.6487"
+       y1="155.59685"
+       x2="1763.6903"
+       y2="-55.941216" />
+    <linearGradient
+       id="linearGradient4046-3">
+      <stop
+         id="stop4048-7"
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4050-73"
+         style="stop-color:#ffffff;stop-opacity:0.2"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Livello 1"
+     transform="translate(0,-540.36218)" />
+  <g
+     id="g2036"
+     transform="matrix(1.1,0,0,0.44444,95.081063,256.39254)">
+    <g
+       id="g3712"
+       style="opacity:0.4"
+       transform="matrix(1.0526,0,0,1.2857,-1.2632,-13.429)" />
+  </g>
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3541" />
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3536" />
+  <g
+     id="g4103"
+     transform="translate(-11.985071,-592.11719)">
+    <rect
+       ry="101.45834"
+       y="612.11719"
+       x="31.985071"
+       height="487"
+       width="487"
+       id="rect6187"
+       style="opacity:0.1;color:#000000;fill:url(#linearGradient4114-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.07999998;color:#000000;fill:url(#linearGradient4112-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6191"
+       width="491"
+       height="491"
+       x="31.985071"
+       y="612.11719"
+       ry="102.29167" />
+    <rect
+       style="opacity:0.2;color:#000000;fill:url(#linearGradient4110-6-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6183"
+       width="483"
+       height="483"
+       x="31.985071"
+       y="612.11719"
+       ry="100.62501" />
+    <rect
+       ry="99.791664"
+       y="612.11719"
+       x="31.985071"
+       height="479"
+       width="479"
+       id="rect6179"
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient4116-6-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient5342-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5574"
+       width="475.5"
+       height="475.5"
+       x="31.985071"
+       y="612.11719"
+       ry="99.0625" />
+  </g>
+  <path
+     style="fill:#77caa9;stroke:none;color:#000000;fill-opacity:1;fill-rule:nonzero;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     d="M 118.34375,20 C 63.867087,20 20,63.867084 20,118.34375 l 0,23.0625 0,252.25 C 20,448.13291 63.867087,492 118.34375,492 l 275.3125,0 C 448.13292,492 492,448.13291 492,393.65625 l 0,-252.25 0,-23.0625 C 492,63.867084 448.13292,20 393.65625,20 l -275.3125,0 z"
+     id="rect5505"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g4076"
+     transform="translate(-605.51932,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038" />
+  </g>
+  <g
+     id="g4076-9"
+     transform="translate(-605.51937,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038-9">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.4;color:#000000;fill:url(#linearGradient4084-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50000000000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m 1650.4994,-310.41615 c -54.4767,0 -98.3125,43.83583 -98.3125,98.3125 l 0,275.343747 c 0,54.476673 43.8358,98.343753 98.3125,98.343753 l 2.9375,0 c -53.3225,0 -96.25,-42.9275 -96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 42.9275,-96.25 96.25,-96.25 l 269.5001,0 c 53.3225,0 96.25,42.9275 96.25,96.25 l 0,269.499997 c 0,53.322503 -42.9275,96.250003 -96.25,96.250003 l 2.9062,0 c 54.4767,0 98.3438,-43.86708 98.3438,-98.343753 l 0,-275.343747 c 0,-54.47667 -43.8671,-98.3125 -98.3438,-98.3125 l -275.3438,0 z"
+         id="rect6809-2-3" />
+      <path
+         id="path3981-7"
+         d="m 1650.4994,161.58385 c -54.4767,0 -98.3125,-43.83583 -98.3125,-98.312503 l 0,-275.343747 c 0,-54.47667 43.8358,-98.34375 98.3125,-98.34375 l 2.9375,0 c -53.3225,0 -96.25,42.9275 -96.25,96.25 l 0,269.499997 c 0,53.322503 42.9275,96.250003 96.25,96.250003 l 269.5001,0 c 53.3225,0 96.25,-42.9275 96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 -42.9275,-96.25 -96.25,-96.25 l 2.9062,0 c 54.4767,0 98.3438,43.86708 98.3438,98.34375 l 0,275.343747 c 0,54.476673 -43.8671,98.312503 -98.3438,98.312503 l -275.3438,0 z"
+         style="opacity:0.2;color:#000000;fill:url(#linearGradient4086-12);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     d="m 136,319.75 c -10.34174,0 -18.75,-8.40826 -18.75,-18.75 l 0,-165 c 0,-10.34174 8.40826,-18.75 18.75,-18.75 l 240,0 c 10.34175,0 18.75,8.40826 18.75,18.75 l 0,165 c 0,10.34174 -8.40825,18.75 -18.75,18.75 l -240,0"
+     style="color:#000000;fill:#6c7990;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path26" />
+  <path
+     style="fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke:none"
+     d="M 136 106 C 119.4325 106 106 119.4325 106 136 L 106 301 C 106 309.58964 109.61994 317.34337 115.40625 322.8125 L 171.75 379.1875 C 168.24951 381.9333 166 386.20532 166 391 C 166 395.35763 167.87727 399.25968 170.84375 402 L 260.8125 492 L 393.65625 492 C 448.13292 492 492 448.13291 492 393.65625 L 492 209.625 L 397.8125 115.40625 C 392.34338 109.61994 384.58965 106 376 106 L 136 106 z M 136 128.5 L 376 128.5 C 380.13701 128.5 383.5 131.86299 383.5 136 L 383.5 301 C 383.5 305.13699 380.13701 308.5 376 308.5 L 136 308.5 C 131.863 308.5 128.5 305.13699 128.5 301 L 128.5 136 C 128.5 131.86299 131.863 128.5 136 128.5 z "
+     id="path3970" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 346,391 c 0,8.28525 -6.71475,15 -15,15 l -150,0 c -8.28524,0 -15,-6.71475 -15,-15 0,-8.28525 6.71476,-15 15,-15 l 150,0 c 8.28525,0 15,6.71475 15,15"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path18" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 293.5,331 c 0,0 -7.5,45 22.5,45 0,0 -150,0 -120,0 30,0 22.5,-45 22.5,-45 l 75,0"
+     style="fill:#e1e3cc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path20" />
+  <path
+     style="fill:#000000;fill-opacity:0.15686275;fill-rule:nonzero;stroke:none"
+     d="M 136 106 C 119.4325 106 106 119.4325 106 136 L 106 301 C 106 317.5675 119.4325 331 136 331 L 376 331 C 392.56751 331 406 317.5675 406 301 L 406 136 C 406 119.4325 392.56751 106 376 106 L 136 106 z M 145.71875 138.5 L 376.28125 138.5 C 380.25602 138.5 383.5 141.68658 383.5 145.59375 L 383.5 301.40625 C 383.5 305.3134 380.25602 308.5 376.28125 308.5 L 145.71875 308.5 C 141.74399 308.5 138.5 305.3134 138.5 301.40625 L 138.5 145.59375 C 138.5 141.68658 141.74399 138.5 145.71875 138.5 z "
+     id="path5055" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 376,106 -240,0 c -16.5675,0 -30,13.4325 -30,30 l 0,165 c 0,16.5675 13.4325,30 30,30 l 240,0 c 16.56751,0 30,-13.4325 30,-30 l 0,-165 c 0,-16.5675 -13.43249,-30 -30,-30 m 0,22.5 c 4.13701,0 7.5,3.36299 7.5,7.5 l 0,165 c 0,4.13699 -3.36299,7.5 -7.5,7.5 l -240,0 c -4.137,0 -7.5,-3.36301 -7.5,-7.5 l 0,-165 c 0,-4.13701 3.363,-7.5 7.5,-7.5 l 240,0"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path28" />
+</svg>

--- a/src/resources/debugMode.svg
+++ b/src/resources/debugMode.svg
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="100"
+   inkscape:export-xdpi="100"
+   inkscape:export-filename="/home/alecive/Scrivania/firefoxTest1.png"
+   sodipodi:docname="debugMode.svg"
+   inkscape:version="0.91 r13725"
+   version="1.1"
+   id="svg2"
+   height="512"
+   width="512">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.69685779"
+     inkscape:cx="-284.77251"
+     inkscape:cy="94.081026"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="false"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     inkscape:window-x="1985"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-nodes="true" />
+  <defs
+     id="defs4">
+    <linearGradient
+       x1="19.244999"
+       y1="21.030804"
+       x2="19.360001"
+       gradientUnits="userSpaceOnUse"
+       y2="44.984001"
+       id="linearGradient2460">
+      <stop
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4114-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0317796,0,0,1.0317796,-827.994,596.98295)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow-0-1-1-5-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0058652,0,0,0.994169,100,0)">
+      <stop
+         id="stop3750-8-9-3-6-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-5-6-4-2-9"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4112-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0402541,0,0,1.0402541,-835.0811,596.82329)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4110-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.023305,0,0,1.023305,-820.90698,597.14261)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4116-6-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0148305,0,0,1.0148305,-813.8199,597.30227)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       y2="20.625916"
+       x2="1006.8082"
+       y1="484.41721"
+       x1="1012.5133"
+       gradientTransform="matrix(1.0074153,0,0,1.0074153,-807.61873,597.44194)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5342-3"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3737-9"
+       id="linearGradient4084-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(771.96984,-365.75459)"
+       x1="993.43896"
+       y1="51.511765"
+       x2="988.78552"
+       y2="363.73825" />
+    <linearGradient
+       id="linearGradient3737-9">
+      <stop
+         id="stop3739-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4046-3"
+       id="linearGradient4086-12"
+       gradientUnits="userSpaceOnUse"
+       x1="1764.6487"
+       y1="155.59685"
+       x2="1763.6903"
+       y2="-55.941216"
+       gradientTransform="translate(-6.6299509,-5.1949584)" />
+    <linearGradient
+       id="linearGradient4046-3">
+      <stop
+         id="stop4048-7"
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4050-73"
+         style="stop-color:#ffffff;stop-opacity:0.2"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient3876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-5.0052516e-5,-3.9999995)"
+       x1="510.99997"
+       y1="515"
+       x2="510.99997"
+       y2="23.999998" />
+    <linearGradient
+       id="outerBackgroundGradient">
+      <stop
+         style="stop-color:#21759b;stop-opacity:1;"
+         offset="0"
+         id="stop3864-8-6" />
+      <stop
+         style="stop-color:#478aa9;stop-opacity:1;"
+         offset="1"
+         id="stop3866-9-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#outerBackgroundGradient"
+       id="linearGradient11020"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,-24)"
+       x1="510.99997"
+       y1="515"
+       x2="510.99997"
+       y2="23.999998" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Livello 1"
+     transform="translate(0,-540.36218)" />
+  <g
+     id="g2036"
+     transform="matrix(1.1,0,0,0.44444,92.211037,252.0875)">
+    <g
+       id="g3712"
+       style="opacity:0.4"
+       transform="matrix(1.0526,0,0,1.2857,-1.2632,-13.429)" />
+  </g>
+  <g
+     transform="translate(94.611037,226.9765)"
+     id="g3541" />
+  <g
+     transform="translate(94.611037,226.9765)"
+     id="g3536" />
+  <g
+     id="g4103"
+     transform="translate(-14.855124,-596.42223)">
+    <rect
+       ry="101.45834"
+       y="612.11719"
+       x="31.985071"
+       height="487"
+       width="487"
+       id="rect6187"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient4114-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07999998;fill:url(#linearGradient4112-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate"
+       id="rect6191"
+       width="491"
+       height="491"
+       x="31.985071"
+       y="612.11719"
+       ry="102.29167" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient4110-6-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate"
+       id="rect6183"
+       width="483"
+       height="483"
+       x="31.985071"
+       y="612.11719"
+       ry="100.62501" />
+    <rect
+       ry="99.791664"
+       y="612.11719"
+       x="31.985071"
+       height="479"
+       width="479"
+       id="rect6179"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:url(#linearGradient4116-6-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:url(#linearGradient5342-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate"
+       id="rect5574"
+       width="475.5"
+       height="475.5"
+       x="31.985071"
+       y="612.11719"
+       ry="99.0625" />
+  </g>
+  <path
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3876);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;enable-background:accumulate"
+     d="m 124.9737,25.194958 c -54.476664,0 -98.343751,43.867084 -98.343751,98.343752 l 0,23.0625 0,252.25 c 0,54.47666 43.867087,98.34375 98.343751,98.34375 l 275.3125,0 c 54.47667,0 98.34375,-43.86709 98.34375,-98.34375 l 0,-252.25 0,-23.0625 c 0,-54.476668 -43.86708,-98.343752 -98.34375,-98.343752 l -275.3125,0 z"
+     id="rect5505"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g4076"
+     transform="translate(-608.38935,-358.27337)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038" />
+  </g>
+  <g
+     id="g4076-9"
+     transform="translate(-598.88942,-348.77337)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038-9">
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#linearGradient4084-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate"
+         d="m 1650.4994,-310.41615 c -54.4767,0 -98.3125,43.83583 -98.3125,98.3125 l 0,275.343747 c 0,54.476673 43.8358,98.343753 98.3125,98.343753 l 2.9375,0 c -53.3225,0 -96.25,-42.9275 -96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 42.9275,-96.25 96.25,-96.25 l 269.5001,0 c 53.3225,0 96.25,42.9275 96.25,96.25 l 0,269.499997 c 0,53.322503 -42.9275,96.250003 -96.25,96.250003 l 2.9062,0 c 54.4767,0 98.3438,-43.86708 98.3438,-98.343753 l 0,-275.343747 c 0,-54.47667 -43.8671,-98.3125 -98.3438,-98.3125 l -275.3438,0 z"
+         id="rect6809-2-3" />
+      <path
+         id="path3981-7"
+         d="m 1650.4994,161.58385 c -54.4767,0 -98.3125,-43.83583 -98.3125,-98.312503 l 0,-275.343747 c 0,-54.47667 43.8358,-98.34375 98.3125,-98.34375 l 2.9375,0 c -53.3225,0 -96.25,42.9275 -96.25,96.25 l 0,269.499997 c 0,53.322503 42.9275,96.250003 96.25,96.250003 l 269.5001,0 c 53.3225,0 96.25,-42.9275 96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 -42.9275,-96.25 -96.25,-96.25 l 2.9062,0 c 54.4767,0 98.3438,43.86708 98.3438,98.34375 l 0,275.343747 c 0,54.476673 -43.8671,98.312503 -98.3438,98.312503 l -275.3438,0 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient4086-12);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <image
+     y="132.77625"
+     x="78.862053"
+     id="image3112"
+     xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAq4AAAIACAYAAABD6e6YAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJzs3Xt8HXWdP/7Xe85Jmpam4abQFBDaCGJtm8yc0xgKbFBw8QIqEMULgvL1tt7W9cKuV2R1V1dZ r6zs6qqIihJhURFREaJYS5Mz56TFcLO0FaGBH5fSlkua5Mz790dOFUqb5nLOeX9m5vV8PPoAhGZe NpnP53U+85kZgIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI iIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI iIiIiIiIiOpKrAMQEcVZd3d30yOPPLKgoaGh2fO85iiK5otIMwCo6g7P8x6LomjH2NjYjgMPPHB7 X1/fiHVmIqK4YnElIpqCIAgWikg7gOdFUXSMiBwD4BgAC6f5pYYB3Kmqd3qedyeAO1R1MAzD4Wpn JiJKGhZXIqI96OrqOnDnzp3dnue9SFVfBODYGh/ydhG5MYqiG+fMmdO3Zs2aR2p8PCKi2GFxJSKq 6OzsPGRsbOx1AF4vIgEAzyhKpKohgB80NDRcsXbt2geMchAROYXFlYhSLQiCeQBeJSLnqOopADLW mXZTFpFfq+rlAK4Jw/AJ60BERFZYXIkolVauXHlQuVz+RwDvAdBinWeKtgH4aiaT+VJ/f//D1mGI iOqNxZWIUiWfzx8aRdEHAbwDwH7WeWbocQCXep73hYGBgfutwxAR1QuLKxGlQmdn54KxsbELReSd AJqs81TJiKp+vaGh4cK1a9dutw5DRFRrLK5ElHi5XO51qnoxpv/oqrgYFpEPFAqFK6yDEBHVEosr ESVWLpc7BsAlqvpi6yz1ICK/AfCuQqFwp3UWIqJacO3uWSKiqgiC4J8AXAXgudZZ6mgxgLe1trY+ MTw8vMY6DBFRtXHFlYgSpaur68DR0dHLALzCOouxaxsbG8/liwyIKElYXIkoMXK53CpVvQLA4dZZ HPEXEXldoVBYbR2EiKgauFWAiBIhl8u9W1V/COAA6ywOaQHwpkWLFm3dsmVLv3UYIqLZYnElotjz ff/TAP4ddq9odZkH4GULFy5sGB4evtE6DBHRbLC4ElFs9fT0ZObOnfvfIvKP1llcJyIntra2Ljr+ +OOvu+2229Q6DxHRTLC4ElEstbW1zXnyySd/BOAN1lliJNi6deuy/fbb75pHHnmkbB2GiGi6eFmN iGKnp6cn09LS8kMAr7bOEkOvbmlp+WFPTw8XLogodjhwEVHszJ07938AvN46R4w9b+vWra3Dw8M/ sw5CRDQdLK5EFCtBEPwbgPdZ50gAv7W1dc7w8PBvrIMQEU0ViysRxUYQBO8D8BnrHAlyQmtr66PD w8NrrYMQEU0FX0BARLEQBMFJAH4NfuCutjKAU8IwvMk6CBHRvrC4EpHzOjs7DxkfHy8BWGidJaGG s9lsx9q1ax+wDkJENBk+VYCIXOeNjY19DyyttbSw8mfMOYGInMZLbkTktCAIPi4i51vnSDoRWdza 2hoNDw//1joLEdHecKsAETkrl8t1qOoA+CG7Xsoiki8UCiXrIEREe8LLQkTkKlHVr4OltZ4ylT9z LmoQkZNYXInISUEQnA+g0zpHCnVW/uyJiJzDT9VE5JyVK1ceVC6X7wRwkHWWlHo4k8kc09/f/7B1 ECKip+KKKxE5J4qifwNLq6WDKt8DIiKncMWViJzS3t5+ZCaT+ROArHWWlBsvl8vPHRwc3GwdhIho F664EpFTMpnMh8HS6oJs5XtBROQMrrgSkTOCIFgIYBOAOdZZCACwE8BRYRgOWwchIgK44kpEbvkA WFpdMgcT3xMiIidwxZWInNDe3r5/JpO5F8B+1lnoaR4vl8uHDQ4OPmodhIiIK65E5ATP814DllYX 7Vf53hARmWNxJSIniMibrDPQnvF7Q0Su4FYBIjIXBMESABusc9Ck2sIwvNs6BBGlG1dciciciJxj nYEmx+8REbmAxZWIzKnqG60z0OT4PSIiF7C4EpEp3/fbACyxzkH7tKTyvSIiMsPiSkTWXmQdgKaM 3ysiMsXiSkSmPM9jGYoJfq+IyBqLKxFZElU9yToETU3le8Wn0RCRGRZXIjKTy+WWAni2dQ6asmdX vmdERCZYXInIkm8dgKaN3zMiMsPiSkRmoig62joDTQ+/Z0RkicWViMyICEtQzPB7RkSWWFyJyEQ+ n18K4ATrHDRtJ1S+d0REdce7Q4mobnzfD0TkTABnAuDKXbzdBeAqVb2qWCyG1mGIKB1YXImoprq6 ug4cHR09D8DbwbKaVHcB+O/GxsbvrFmz5hHrMESUXCyuRFQT+Xz+uHK5/A4R6QHQZJ2H6mJEVXsz mcylAwMDf7AOQ0TJw+JKRFWzatWq5pGRkTcCeAeA5dZ5yNR6AJc2NTV9b/Xq1TuswxBRMrC4EtGs 5XK5FwB4j6q+HsB86zzklMdE5AcAvlooFP5oHYaI4o3FlYhmLAiCZar6SRE5AxxPaHKqqlcDuKhY LK63DkNE8cSJhoimjYWVZkFF5P/K5fJFpVJpnXUYIooXTjg0LatWrWreuXPnSQAOBnBwFEUHAThY RA4CcLCqPiwivwBwXRiG95iGpapjYaUqUgDXeJ530cDAwKB1GKoq8X3/eBE5S0SaoyhSEVFMfM9V RDSKosdF5OowDH9vHZbihRMPTUk+nz80iqL3AXgngJYp/rYhEbkOwHWqujoMw7HaJaRaYmGlGlIA P/E871MssPGWy+WOiaLoHBF5A4Ajp/jb7gLwbQCXhWE4XLNwlBicgGhSK1euPLpcLn8QwJsAzJnF l3pURN5bKBQur1I0qoNly5YdMGfOnM+q6lvB8YJqS1X129ls9sP9/f0PW4ehqenq6po7Ojr6VlV9 o4jkZ/GlygCuV9VvLVmy5Ce9vb3lamWkZOFERHvU3t7+3Gw2+1lVfRWq+2rg7wB4VxiGT1Txa1IN BEFwLoDPA3iWdRZKlYdF5IJCofAtTKzGkqOWL1/+7IaGhp8C6Kzyl/5lU1NTDx+jRnvC4krPkMvl jlHVPgCH1ugQt4vIa/hoHDfl8/mlURR9HcAJ1lko1VYDeGcYhrdaB6Fn6ujoeL7neT/H1LcETNdg FEUvL5VKW2r09SmmWFzpaSpbA/oALKzxoZ4E8N4wDL9Z4+PQFC1fvny/xsbGT6rq+wFkrfMQARgH 8KWxsbEL169f/7h1GJrQ0dHxYs/zrsLU73eYqb+IyMu4yEFPlbEOQO5ob29/LoA+AK11OFwDgNMX LVrUuGXLlhvrcDyaRBAEr8pkMj8H8FJUd2sI0Wx4AI7LZDLntLa2bhoeHr7DOlDa5XK5t4jIDwHM q8PhWgC8YeHChf3Dw8Ob6nA8igGuuBIAwPf9NhHpA7Cozocui8hxhUKhv87HJQBtbW1z9t9//6+o 6tussxDti4j8z/z589/X19c3Yp0ljXK53PmqanGVbExEXlUoFK4zODY5hsWV0NHR0ep5Xj/qX1p3 GRoZGfGHhoZGjY6fSitXrjyqXC7/GIBvnYVoGkqe5501MDCw0TpImnR2di4YHx/fALubNe8GcCwf q0i8JEjwPO8DsCutALC0qanpo4bHTx3f908rl8tFsLRS/HREUVQMguBV1kHSZGxs7KOwfcLIEl4Z IoArrqkXBEELgL8AaDaOMqaqOb7DvLZ6enoyGzdu/AyAD4PnP8Xfxc3Nzf/c19c3bh0kyTo6Op7j ed6dmN2zvKvhgZGRkbahoaHHjHOQIa64plzlE6x1aQWABs/z/renp4c3DNZIPp8/9O677/4NgAvA 0krJ8IEdO3b0rVixwvKKUeKJyGdhX1oB4JCmpqZ/sg5Btjh5pVgQBA0ANsF2m8DTqOppxWLxWusc SeP7fiAi16J2z+YlsvSgqp5eLBZvsQ6SNEEQdAJYA3f6wo4oipaUSqUHrYOQDa64ppiInA2HSisA iMgq6wxJk8/njxOR34CllZLrWSLy63w+/3fWQRLo43CntAJAs+d5F1iHIDssrimmqh+0zrA7Ve2y zpAkQRCcFEXRr1D7B4UTWZsfRdEvfN//e+sgCfNC6wC74zyRbiyuKdXR0fEsAMutc+xORPLd3d18 a1MV5HK5lwK4DsB+1lmI6mSuiPw0l8u90jpIElT2Dh9knWN3IrLYOgPZYXFNr3q8HWsm5m3fvn2F dYi4833/1ap6DYAm6yxEddaoqj/2ff+11kHiLpvNtltn2ItDly9fzg/kKcXimlIistA6w96IyHHW GeIsl8u9TkSuBNBonYXISFZEvh8EwbnWQeJMRFwtrmhsbDzKOgPZYHFNKc/zXF1xBQDuX5oh3/ff qKrfA8DtFpR2GQDfzuVy51sHiStVdba4AlhiHYBssLiml7Mrrqr6HOsMcdTR0dElIv8LntdEu4iq fr2jo+NE6yBxpKrOLnCoKotrSnGCSylVPcQ6w96ICPcuTdOKFSsWeZ53Nbg9gGh3DZ7n/Tifzx9u HSRuHB+LucCRUiyuKaWqLr8icZ51gDjp7u5uymazV4PPaSXam2dFUXRNV1fXXOsgMePsWKyqZesM ZIPFNaVE5HHrDJNwdrB00Y4dO/4bwErrHESO80dHR79hHSJmnB2LHZ/DqIZYXNPrCesAk3D58pRT crnc+wG8yToHUUy8IQiCD1iHiBGXx2KX5zCqIRbX9HL506qzn/Jdks/nT1bVz1vnIIqZz+VyuVOs Q8SEy2Oxy3MY1RCLa3q5/Gm1saenJ2MdwmWdnZ2HRFH0I0w88oeIpi6jqj/s7Ox09gZVF1TGYJdv 9nR5DqMaYnFNKdf3B91zzz0uX6IyNz4+/jkAB1rnIIqpA8fHx//DOoTLXB+DXZ/DqHZYXNPL6U+r URS5fInKVD6fPw7c10o0W28KguB46xCuisEY7PQcRrXD4ppSMfi06vqgaaKnpycTRdElAMQ6C1EC XMJtSXvl9BgcgzmMaoTFNb2c/rQaRZHTl6msbNy48e0AXH4NI1GcLN+4ceO7rUO4KAZjsNNzGNUO i2tKjY+Pu/5p1elP+xaCIDgYwKetcxAlzEX5fJ4v73gmp8fgGMxhVCMsrimlqq5/WnV60DTyWQAH WIcgSpgF5XKZN2o9k9NjcAzmMKoRFteUcn1/kKq6fpmqrvL5fB7AW6xzECWRiJzDG7WezvUx2PU5 jGqHxTWlPM9z/aR3+tN+vUVR9GHwhiyimhGRD1tncIzTY3AM5jCqERbX9HL9MovTg2Y9VfbfvdI6 B1GSqerLOjs7D7PO4RDXx2DX5zCqERbXlArDcAzAmHWOSTh9maqeVPV8AA3WOYgSLjM+Pv5W6xAO cXkMHqvMYZRCLK7p5vInVtc/7deLp6pvsw5BlBLn87muf+XyGOzy3EU1xuKabi7vEXJ50Kwb3/df BuAI6xxEKbFo06ZNr7AO4QiXx2CX5y6qMRbXdHP2U6vneS5fpqobEXmHdQailOE5B+fHYGfnLqo9 Ftd0c/lT68HWAax1dHQ8B8BLrXMQpYmqvqS9vf1I6xwOcHkMdnnuohpjcU0xEXH5U+sS6wDWMpnM 28BzlKjevGw2y5u0HB6DHZ+7qMY4KaZYFEXOfmpV1cXWGayp6unWGYjSiOee22Owy3MX1R6La4qJ yCPWGSbR2tbWNsc6hJVly5YdAGCpdQ6ilFpaOQdTqTL2tlrn2BvP8x62zkB2WFzT7X7rAJPw9t9/ /yOtQ1hpbGw8DnxTFpEVqZyDqVQZe53tB6r6gHUGsuPsDybVnohsts6wD85eqqqDE6wDEKVcms9B p8feGMxdVEMsrum20TrAZKIocnrwrLHjrQMQpVxqz8EYjL1Oz11UWyyuKRZF0SbrDJMREdcHz5qo 7C/LWecgSrlcWvfZuz72uj53UW2xuKbYzp07Xf/U6vTgWSstLS15AKmcMIkcMqdyLqaR02NvDOYu qiEW1xQbGhp6DMBD1jkm4fTgWUOpvURJ5Ji0nosuj70PVeYuSikWV3L5k6vLg2fNiEhq72YmckmK z0WXx16X5yyqAxbXlFNVlweB+cuXL3+2dYh6U9XDrTMQUTrPxcqYO986x944PmdRHbC4ppyIOL3J PZvNuvzJv1YOtA5ARACAg60D1JvrY67rcxbVHosrOf3p1fW7W2vkIOsARAQghediDMZcp+csqj0W 15SLwWUX1wfRqqo8fmc/6xxEBACYGwTBPOsQdeb0mBuDOYtqjMU15bLZrNOXXWLw6b+qWlpauE2A yCGe56Vq1dX1Mdf1OYtqj8U15ebNm/cXAOPWOfYmBm9wqSoRSdUkSRQDqTonHR9zxytzFqUYi2vK 9fX1jQO4xzrH3ohIm3WGeiqXy1xxJXJLqm7QcnzMvacyZ1GKsbiS63dpLgqCYKF1iHrhiiuRW8rl cmrOycpYu8g6x944PldRnbC4kvOb3dP0EHDP87jiSuSW1Ky4uj7Wuj5XUX2wuBIAOP0pVlWdHkyr bK51ACL6GxFJzTkZg7HW6bmK6oPFleLwKXaVdYB6UdUR6wxE9DcikqZz0umxNgZzFdUBiyshk8m4 Phh0dHd3N1mHqAcWVyK3pOWcrIyxHdY5JhODuYrqgMWVICKuDwaNO3bsyFmHqAfP8560zkBEf6Oq qTgnK2Nso3WOycRgrqI6YHEl9Pf3Pwxg2DrHPjh9Cata0rK6QxQXnuel5Zx0fYwdrsxVlHIsrrRL 0TrAZGJw00BVpGV1hyhGUnFOxmCMdXqOovphcSUAgIissc4wGdcf01ItmUwmLas7RLEQRVEqzknX x1jX5yiqHxZX2mW1dYB9OHjlypVHW4eoNa64ErklDedkZWx1/Xm1rs9RVCcsrgQAUNV+AE6/Sm98 fNzpFYFqSMvqDlFcpOEqSAzG1vHKHEXE4koTwjB8QkQGrXNMxvVLWdWgqk9YZyCip0n8Oen62Coi g2EYJv77QFPD4kp/paquX4px/a7XWWtpaXnAOgMR/Y2q3m+doQ6cHltjMDdRHbG40lO5Pjgcu2zZ sgOsQ9RSX1/fCICHrHMQEQDgsTAMt1mHqKXKmHqsdY59cH1uojpicaW/iqLI9cFBGhoajrcOUQd/ sQ5ARABScC5WxlSxzjGZGMxNVEcsrvRXpVJpC4DN1jkmIyJnWWeoNRG51zoDEQEAEn8uxmBM3VyZ m4gAsLjSM/3BOsA+vKqtrW2OdYhaUtXET5ZEcZD0D5GVsfRV1jn2wfU5ieqMxZV25/olmQX777// qdYhaonFlcgNST8XK2PpAusc++D6nER1xuJKTxOHvUSq+lrrDLXkeV7i99URxYGqJvpcjMNYGoc5 ieqLxZWeplQq3Qpgu3WOfTitq6trrnWIWkn6Kg9RXHiel9hzsTKGnmadYx+2V+Ykor9icaXdRQBu sQ6xD/PHxsZebh2iVsrl8ibrDEQEqGpiz8XKGDrfOsc+3IKJOYnor1hc6RlU1fnN8HG4xDVTg4OD mwE8Yp2DKOUeC8PwLusQtRKHMTQOcxHVH4srPUMmk4nDnqKXL1261PXVgtkYsA5AlGaqGiKhq32V sdP5q1YxmYuozlhc6RmeeOKJWwCUrXPsw9y5c+e6vj9rNlhciQyJSGLPwcrY6fp9AuXKXET0NCyu 9AxDQ0OPARi0zrEvcbjUNVNJnjSJ4kBVE3sOxmTsHKzMRURPw+JKeyQiv7TOMAWndnZ2uv4MwhlJ 8qRJFAfZbDaR52BlzHT+WdgxmYPIAIsr7VG5XL7WOsMUzCmXy66/9WVGwjAcBnCfdQ6ilHqov78/ kU8UqIyZzr99MCZzEBlgcaU9KpVKtwC4xzrHvqjqG60z1FC/dQCiNEryFY+YjJn3VOYgomdgcaW9 UQBXWoeYglOCIFhmHaIWRIQDN5GBpJ57lbHyFOscU3AlJuYgomdgcaW9iqLoR9YZpkJVP2SdoRbG x8f/zzoDUUol8tyLy1gZl7mHbIh1AHJbEAQbACyxzrEPY57nLRkYGEjce8WDIBgEsMI6B1GK3BmG 4fOsQ1RbPp8/PIqiuwE0WGfZh7vDMGyzDkHu4oorTUpE4vDJt6FcLr/fOkQtiEivdQailEnkOVcZ I10vrXGZc8gQiytNKi6XbETkre3t7ftb56g2z/MSOYkSuUpVE3fOtbe37y8ib7XOMRVxmXPIDosr TapYLK4HcLt1jimYn8lk3mkdotr6+/vvArDeOgdRStxVGfMSpTI2xuEV2bcn8c+fqovFlfZJVePy Cfi9bW1tzj+fcAYStwJE5KIkrrZWxsT3WueYihjNNWSIxZX2KUZ7jg5dsGDBm6xDVBv3uRLVRxKL a2VMPNQ6x1TEaK4hQyyutE9hGN6BmFyuFpEPIGFPyygUCncCuMk6B1GSiciaUqm0zjpHlUllTIyD 9ZW5hmhSLK40VT+0DjBFxwRB8ErrENWmqp+2zkCUcIk7xypj4THWOaYoLnMMGWNxpSnxPC9Ol3Au sA5QbcVi8UYRWWOdgyihioVC4TrrEDUQm7EwZnMMGWJxpSkZGBjYKCIF6xxT9ELf919rHaIGErci ROQCVf2MdYZqq4yBL7TOMRUiUhgYGNhonYPigcWVpkxVY3MpR0QuXrp0aRwe/zJllRWhknUOooQZ KhaLiXrF69KlS+eLyMXWOaYqTnML2WNxpSmLougKAGXrHFO0aM6cOR+3DlFt3OtKVHX/BkCtQ1RT ZexbZJ1jisqVuYVoSlhcacpKpdIWEYnNPjAReX8QBIl653hlZeiP1jmIEuJPixcvTtTeyiAInici sXkFtohcVyqVtljnoPhgcaXp+qp1gGloAPAV6xBVplEUvQ1AZB2EKOZURN7W29sbl6tIU/UVTIx9 cRGnOYUcwOJK01IoFH4NYNA6xzScksvlzrIOUU2lUmmNqn7BOgdRzH21UCj0WYeopspYd4p1jmkY rMwpRFPG4koz8XnrANOhqv8ZBME86xzVtH379k8AuM06B1FM/QnAv1iHqKYgCOap6n9a55imWM0l 5AYWV5q25ubmKwHcY51jGg4XkY9ah6imDRs27Iyi6FwA49ZZiGIm8jzvvDAMn7AOUk2VMe5w6xzT cE9lLiGalox1AIqfzZs3RwsXLoSInGqdZRo6DznkkB/df//9j1gHqZb7779/S2trayOAE62zEMXI xYVC4VvWIaqpvb39uSLyPcRoTlfVC9esWfMH6xwUP1xxpRnZuXPnNwFstc4xDY2ZTObb3d3dWesg VXYRgKS9X52oVm5rbm5O1GPyuru7s5lM5tsAGq2zTMPWyhxCNG0srjQjQ0NDjwG41DrHNK167LHH PmUdoprCMByLouiVAO6zzkLkuAcAnN7X1zdiHaSaKmPaKusc03RpZQ4hmjYWV5oxz/O+AmCndY7p UNV/zufzJ1vnqKZSqfTnKIpeAiAx2yCIqmxbFEV/H4bh3dZBqimfz5+sqv9snWOadlbmDqIZYXGl GRsYGLgfwOXWOabJi6Loe52dnYdYB6mmUql0G4CXAXjcOguRY55U1dNKpVKittR0dnYeEkXR9xC/ efzyytxBNCNx+4En91yM+L0u8ZDx8fHLAYh1kGoKw3AtgDMAjFlnIXLEuKq+tlgs3mwdpMqkMobF 7QO4YmLOIJqx2NyBSG4aHh5+aOHChb6IHGOdZZqWtLa27hweHv69dZBqGh4evnvhwoV3icgZSFgx J5omFZG3hGHYax2k2oIg+BcAb7POMV2q+rNisfg16xwUb1xxpVkTkbg+RPqifD5/nHWIaisWiz9S 1f8HrrxSeo0D+IdCofBd6yDVVhmzLrLOMRMxnivIIVyRoarI5XJ/UNUu6xwzcM/o6Gj7rbfeGqdH e01JEATHA/gx4nc5kWg2HgLwmjAMb7IOUm3Lli07oLGxcRDAEdZZpktE1hQKhcQtFFD9ccWVqiKK oliuAAA4orGx8Sfd3d1N1kGqLQzD32ez2ZyqDlhnIaqTwSiKckksrd3d3U2NjY0/QQxLKxDrOYIc w+JKVVEsFq8Xkd9Z55ihE7Zv3/6jnp6exO35Xrt27b0LFiw4EcBl1lmIauwKAKtKpdKfrYNUW09P T2b79u0/AnCCdZaZEJHfFYvF661zUDIkbqImOwsXLlwP4K2I4RYUETnm0UcfPXzLli0/sc5SbZs3 bx4fHh6+prW1dSuAU8APrJQsZVX952Kx+IHh4eFE7uueN2/e/wI42zrHDEUAzhweHh62DkLJwOJK VTM8PDzc2tq6EEDOOssMdSxcuHDe8PDwDdZBamF4eHhta2vrTQC6ADzLOg9RFdwF4LXFYvH71kFq xff9zwF4t3WOWfjvMAz5eleqGq68UFU1NjZ+FMDD1jlmSkQ+HATBB61z1EoYhr8HsEJELgBfVkDx 9YSqfnRkZGRZEvez7hIEwQdF5MPWOWbh4cqcQFQ1XHGlqrr33nufXLRo0TYAr7DOMguntLa2bh4e Hk7Um3Z2GR4ejrZs2bL6iCOO+G4URUcAeL51JqKpEpGrAZxWLBavffDBB8vWeWolCIJzAVyCGG69 2kVE/qm/vz9Rz8ome7E9IchpXhAEAwB86yCzsOuNO1dbB6m1IAheAuCrAI62zkI0iT+p6nuKxeIv rYPUmu/7Z4jIjwBkrbPMQjEMwzwm9rgSVQ23ClAtRFEUvRvxexXsU2VF5MpcLne+dZBaC8PwVyMj I8sAfAQTz8AkcslDAD4yMjLygjSU1lwud76IXIl4l1atzAEsrVR13CpANXH//fff29raehSAduss s+ABOH3hwoVjw8PDSXvX+dM8+OCD5eHh4d8feeSRXyuXy/diYvX1IOtclGp/AvCxxsbG8/r7+29K 8raAXXzf/wiALyP+i0rf5atdqVa4VYBqprOz85Dx8fE7AbRYZ6mCL4dh+H7EexV5OsT3/VcA+ICI /J11GEqVm0Xk4kKh8DOkZ8VOgiD4IoD3WQepgm3ZbPaYtWvXPmAdhJLvE4B/AAAgAElEQVSJxZVq yvf9fxSRL1rnqJIrAJwbhmEinxW5N77vByLyAQA9iPflS3JXGcBVlcLabx2mnoIgaMDEC0JeZ52l GlT1/cVi8UvWOSi5WFypprq7u7M7duwYBLDUOkuV/GpsbOyM9evXp+5RUvl8/vByuXyOiPQg3ltA yB3rAfSWy+XvDQ4ObrYOU2/Lly/fr6Gh4WoAL7HOUiVDzc3N7X19fePWQSi5WFyp5oIgOAnAjdY5 qui2KIp6SqXSbdZBrPi+3yYiZ2FiFTbOT4+g+iup6o+jKOodHBz8k3UYKx0dHc/3PK8XyXoc3YuS /FxdcgOLK9VFEATfBnCedY4qekJV31UsFr9jHcRaPp9frKpnAehR1bi+NY1qKwTQC+DHYRjebR3G mu/754nIJQDmWWepou+EYfhm6xCUfCyuVBft7e37ZzKZPwJYZJ2lyr4/Njb29jRuHdiTlStXHlUu l08DcELl1yHGkcjGAwBuBnBzJpP5WX9//ybrQC6obA34LwBvss5SZfeVy+UXDA4OPmodhJKPxZXq pqOj40TP825E8h7D9piqfkFVv1EqlbZYh3FJe3v7c7PZ7AmqegKA4wG0WWeimtgA4PcicvP4+PjN ad4CsDf5fH5pFEW9AI61zlJl5SiKXlQqlX5nHYTSgcWV6ioIgo8B+FfrHDWiqvobz/P+s1AoXI/0 PDpryvL5/KFRFO1ajT0eEzftNdqmomkaBTAE4PcAbvY87+aBgYH7jTO5zAuC4N0A/h3J2hqwy8fD MPy0dQhKDxZXqjfP9/1fisjJ1kFq7HZV/eKCBQsu7+vrG7EO46ru7u7sY489tkRVj1XV53ued6yq HgvgeQD2s86Xco8DuENEbo+i6HYRuU1Ebp8/f/7dvGt8anzfXy4i3wCw0jpLLajqDcVi8e+Rnuft kgNYXKnuKi8mGARwqHWWOngIwNez2ewlfCD3tEhHR8cRmUzm+ZUiu+vX4QAWAmgwTZccYwCGAfwF wO0AbheR28vl8m2lUuke8KrBjHR1dc0dHR39BIAPIrnPPr4/m822c1yjemNxJRO+779IRH6N+L/a cKp2ArhCVb9YLBbXW4eJOVm+fPmzGhsbF0VRtMjzvEWqughAq4js+vtFAA40zmntEQD3ich9qnof gC0icl8URfd5nnff6OjofevXr38QLKdV5fv+qSLyNQBLrLPUUKSqpxSLxSQ95pBigsWVzARB8CkA n7DOUW+qeoPneV8sFAq/AEtDzXR3dzc9/vjjreVy+QAALSKyQEQWqGqLiCwA0BJF0YJdfw/gqX9d gImtCg2o/zipmFgJfRzA9sqvbbv+qqrbPc/769+LyDZV3a6q2wFsy2QyW/fbb78t3KJSX77vv1BE /h1At3WWOrgoDMNPWoegdGJxJTM9PT2ZjRs33oB0DPR7coeIfKmhoeG7a9asedI6DO2V19bW1jBv 3rys53kNmUwmC6DB87wsgAZVbRCRLICG8fHxLIBd/wxVHQcwls1mxwGMqeq4iIwBGIuiaBzAWLlc Ho+iaOyJJ54Y37Bhwxi4XzBWKi8S+AyAV1lnqZO+xYsXn9zb21u2DkLpxOJKpoIgWAhgHYBnWWcx 9DCAr3uedwnvziaKBcnn8y+OoujdAE5HeubSBwGsCMNw2DoIpVdaTjZyWBAELwFwPfjzOArgiiiK vlgqldZZhyGip2tvb9/f87zzROSfMHGjYJoogFPDMPyVdRBKt7QXBXJELpe7UFW5Z+pvblTVLxWL xZ+Dl46JTAVB4AO4AMCrkdInWojIpwqFwoXWOYhYXMkVEgTBDwG8xjqIYzYCuKRcLn+Lr1Mkqp+O jo4uz/POBnAWgFbrPMauDMPwbPBmUnIAiys5o62tbU5LS8v1SO/NWpN5HMB3oyj6WqlUus06DFFS 5XK5blX9MoDl1lkc0bdt27ZTN2zYsNM6CBHA4kqO6ezsXDA+Pt4HoMM6i6tU9QYAX+E2AqLq8X3/ zSLyKaRv7+pkStlstnvt2rXbrYMQ7cLiSs6pvFnr9wDarLM4jtsIiGahMtb8C4DzAcy3zuOYDdls 9ni+GYtcw+JKTlq5cuVR5XJ5NSZe70mTexzAdyuP0xqyDkPksra2tjn777//aap6HoBTAWSMI7lo OJPJrOrv799kHYRodyyu5Czf95eLyO8w8TYjmgJVHQBwWTab/WF/f//D1nmIXJHL5VZWyurZAA4w juOybap6Il9NTa5icSWn+b5/goj8CkCTdZaYGRWRawFcpqq/CMNwzDoQUb2tWLFiUTabfSOA8wA8 zzhOHIyo6kuKxeLN1kGI9obFlZyXy+VOV9WrwUt6M/UggB+IyGWFQqFkHYaolipv43s1Jh5j9XcA PNtEsVEWkTMKhcJPrYMQTYbFlWKhcsfv/4I/s7O1HhNbCb7Pmy4oKfL5/OHlcvlMETkTwHFgWZ0u VdXzi8Xit62DEO0LSwDFRi6Xe7eqftU6R0KMA/glgMu2bdv2Uz6jkeImn88vrpTVswDkwflsxkTk PYVC4WvWOYimgic6xUoQBO8E8DVwRaWatorINVEUXTt37txfr169eod1IKI9yeVyxwA4S1XPBJ/1 XA0RgHeHYfh16yBEU8XiSrHj+/4ZIvJ98IatWhgF8FsAPwdwbRiGdxvnoZQLgmCZiJypqmcBWGqd J0FGVPUNxWLxausgRNPB4kqxVHnawE8B7G+dJeHuAPBzEbl2/vz5v+/r6xu3DkTJtmLFikUNDQ0v jqLoZBE5GXyWcy08qqqn8+kBFEcsrhRbuVzuBar6CwCHWWdJiW0Afiki11YesfWQdSCKvyAIWkSk +ylFlY+tqq17ReSlhULhj9ZBiGaCxZViLZ/PHx5F0fUAnm+dJWUiEVkbRdG1AK7lw8ppqpYuXdo4 b968riiKTgZwMiZurOKj7urjNs/zTh0YGPiLdRCimWJxpdhbtmzZAY2NjT8DsMo6S4r9BcCvANwC YG0YhkOYuPGDSDo6OpZ7nneyiJysqicCmGcdKoVWj46OnnbrrbdutQ5CNBssrpQI3d3dTTt27LgC wKussxAA4DEABQBr8bcyO2wbieph5cqVB6lqh6r6qpoD0A3gWcax0u6a5ubm1/X19Y1YByGaLRZX ShIvCILPAfigdRDao79gosjuKrPFMAyfsI1Es7FixYpFmUzGF5EOAD4mHlF1hHEserovhGF4AXgF hBKCxZUSx/f914jINwAssM5CkxoHcCuAtaq6FsDaYrF4BwC1jUV7IL7vL9mtoPrgSqrLtqvqW4vF 4pXWQYiqicWVEsn3/TYRuRJ8SHncbAPQD2CtiKyLouguEdnAldn66enpyWzatOlYVMppFEUdlcLK D4LxUVLV1xSLxQ3WQYiqjcWVEqutrW1OS0vLFwG80zoLzYpi4hE+d6nqXap6l+d5d6rqXYsXL97c 29tbtg4YJ11dXXPL5fLhqnpEuVw+HBOX9o8AcISIHA7gOeDLPeLsv7Zt2/ZPfI0zJRWLKyUetw4k 2iiAjSKyWVXvE5F7oyi6z/O8e6Moum/OnDn3rlmz5hHrkHXkdXR0HCoiTy2iRzzl1+Hg5f2k4tYA SgUWV0oFbh1ItScB3AfgXgD3icgWVX1YVbeKyFYRebRcLm/1PG9rY2Pj1sMOO2ybS6u4y5cv3y+T ybRg4i1xLZlMZn8ALap6gIgchkopVdUjACwC0GAYl2xwawClBosrpUZl68DnAbzHOgs5TQFsB/Ao gK2VX08AGMPECu+YiIwCGIui6Gn/vOvfV/4KTJTI3X81TvK/LwDQUvm1f+Wv2dr+36WY++q2bds+ xK0BlBYsrpQ6vu9/WkQ+ap2DiGg2VPXUYrH4S+scRPXkWQcgqjfP8+60zkBENFtz5879g3UGonpj caXUiaKId0wTUeyNjIzMt85AVG8srpQ6IsLiSkSxVy6XWVwpdVhcKXVUlcWViGIvm82yuFLqsLhS 6ojIXOsMRESzFUURiyulDosrpRFXXIko9jzPY3Gl1GFxpdThVgEiSgJVZXGl1GFxpdThzVlElAQs rpRGLK6URtzjSkSxJyIsrpQ6LK6UOtwqQEQJweJKqcPiSqnDrQJElARccaU0YnGl1FHVOdYZiIhm S1X3s85AVG8srpQ6IpKxzkBEVAVccaXUYXGlNBLrAEREs8UVV0ojFldKHRHhzz0RxR6vHlEacQKn 1FFVrrgSUeypKudwSh3+0FMa8eeeiGKPK66URpzAKXW44kpEScAVV0oj/tBT6niex+JKRLHH/fqU Rvyhp9ThKgURJYGqcqsApQ4ncEojrrgSUexxxZXSiD/0lDoc7IkoITiWUerwh55ShzdnEVFCcKsA pQ6LK6URf+6JKAk4llHq8IeeUocrrkSUBNz2RGnEH3pKHT4Oi4iSgE8VoDRicaXU4eOwiCgJuOJK acQfekojrrgSUezxQzilEX/oKY34c09EsSci3CpAqZO1DkBkgCuuVAu/B7AWQLHyCwD8yq9OAMcb 5aKE4oorpRGLK6URB3uqpj8CeG8Yhjft4d/dAeAHABAEwUkAvgLgBXXMRsnGsYxShz/0lEZccaVq 2CYi71m8eHH7Xkrr04RheNPixYvbReQ9ALbVIR8lH7cKUOpwAqfUCYJgCMDzrXNQrG2PoujFpVKp MJPf3NHRkfM87zcAFlQ5F6XLUBiGXMGnVOGKK6URf+5pNh4XkZfNtLQCQKlUKojIywA8XsVclD4c yyh1uOLqoCAIWlR1OYDlIrICwHIAywDMs01GlHpPAnj5VLYGTEVl3+vPAcytxtcjohkbAbABwJ8A 3CUif4qi6K4FCxas6evrGzfORk/B4uqISln9pIicAeA51nmI6JlU9bXFYvHKan5N3/dfIyI/qubX JKKquVtVP71gwYLvscC6gcXVnvi+f66IfA7As63DENFeXReG4ctr8YWDIPg5gJfV4msTUVWwwDqC xdVQEAQ+gEsAvNA6CxFN6slMJrO0v79/Uy2++MqVK48ql8tD4JYBItfdraqfXrJkyeW9vb1l6zBp xEdpGAiCoGXhwoVfFpFLARxunYeIJicinxoYGPhprb7+fffd9+iiRYsA4EW1OgYRVcWBIvKqRx99 dPGWLVuusQ6TRrwjsc56enoyqvpjEXk7+OdPFAd3Pvnkk5+v9UEqx7iz1schotlT1TcGQfBl6xxp xBXXOmtqarpYRN5gnYOIpkZE3rlu3bpba32cBx98sLxo0aL7Abym1scioqroXLRokWzZsqXPOkia cMWvjnK53Dki8n7rHEQ0ZffPnz+/bpcDK8e6v17HI6LZUdVPBkHwHuscacIV1zrJ5/N5Vb0aQNY6 CxFN2ZfWrFnzm3odbPPmzVFra+v+AE6s1zGJaNZOXbhw4d3Dw8PrrYOkAVdc6yCfzx8aRdH/AWiy zkJEUxYB+IbBcb9ROTYRxYOIyDc7OjqeZR0kDVhc6yCKoi8DWGSdg4im5bowDO+p90Erx7yu3scl olmZ43ne+dYh0oDFtcaWLl06H8Bp1jmIaNouTemxiWhm3gH2qprjH3CNzZ079xXgQ8WJ4uaBMAx/ YXXwyrEfsDo+Ec3Ic3zfr8nb9ehvWFxrTFX5aBui+LkRtvtMo0oGIooRz/P+wTpD0rG41tCqVaua AbzUOgcRTY+q3sQMRDRdqvr3QRAssc6RZCyuNTQyMnIa+CQBojhyoTS6kIGIpkcAnGsdIslYXGur xzoAEU3bvcVicYN1iEqGe61zENH0qOqzrTMkGYtrDakqH4FFFDMuXaJ3KQsRTdk86wBJxuJaQ57n PWmdgYimzaWy6FIWIpoCEeGThGqIxbW2nrAOQETTE0WRM2XRpSxENGUsrjXE4lpDqsoVV6J42To4 OLjZOsQulSxbrXMQ0bSwuNYQi2ttsbgSxYiqmt+UtTsXMxHR3nGrQG2xuNYWiytRvNxtHWAPXMxE RHuhqpYvL0k8Ftfaetw6ABFNnYg4t7rpYiYi2jtVvc46Q5KxuNaQiPzSOgMRTZ2qOre66WImItq7 KIp6rTMkGYtrDRUKhesBbLTOQURT4+LqpouZiGiv1g0ODv7JOkSSsbjWVqSql1qHIKKp8TzPuZLo YiYi2jNVvdI6Q9KxuNZYNpv9FoAR6xxEtE+PDwwM3G8dYneVTNwvTxQD3CZQeyyuNdbf3/8wgB9Z 5yCifXJ5L6nL2YhoArcJ1AGLax2IyH9ZZyCifXrAOsAkXM5GRIACuNA6RBqwuNZBoVDoF5GrrXMQ 0aRcvhzvcjYiAv41DMNrrEOkAYtrnTz66KOvB8D3jhO56wnrAJNwORtR2v0kDMMLrUOkBYtrnWzY sGFnU1PTK0WkYJ2FiPbI5VVNl7MRpdltTU1N52BiqwDVAYtrHa1evXqHqr4UwB3WWYjo6UTE2XLo cjaiFNuqqq9cvXr1DusgacLiWmdhGD6UzWZPAXCPdRYi+psoipwthy5nI0qpR6Io6ikWi3zOcp2x uBpYu3btveVy+WRV/a11FiKa4PKqpsvZiFImUtX/zmQyR5dKpd9Yh0mjrHWAtKo86607l8t1R1F0 oYj8nXUmopRz+QYol7MRpcUtAN5VLBaL1kHSjMXVWKFQ6AMLLJELXF7VdDkbUdL9f6p6QbFYvAy8 Ccsci6sjdiuw54jI0QCeC+AQ22RE6eDy5XgReVyV8yVRHewEcDuA9QBuVdVb586d+wfegOUOFlfH VAps365/7uzsXDA2NvZcAG0A5hrFSjQR+SSAI61zkC1VfdI6w964nI3qarOqfso6RBKJyONRFA21 tLTc1dfXN26dh/aOxdVxa9eu3Q4grPyiGvB9/4Ui8nbrHEREk1HVXxaLxe9Y5yCyxKcKUOrxpRBE FAccq4hYXIngeR4nAyJyHscqIhZXIuy3335/BDBinYOIaBIjlbGKKNVYXCn1Khvx11nnICKaxDre NETE4koEgHvHiMhtHKOIJrC4EgGIooiTAhE5i2MU0QQWVyLwpgcichvHKKIJLK5EAI466qjbAfDN KETkoh2VMYoo9VhciQD09vaWAdxgnYOIaA9uqIxRRKnH4kr0N9dZByAi2gOOTUQVLK5EFePj47+w zkBEtDuOTUR/w+JKVLFu3br7AKy3zkFE9BTrK2MTEYHFlWh3XNkgIpdwTCJ6ChZXoqeIooh7yYjI GRyTiJ6OxZXoKVpaWv4AYJt1DiIiANsqYxIRVbC4Ej1F5V3gv7bOQUQE4NeVMYmIKlhciXajqrw0 R0TmOBYRPROLK9FuROR6AGqdg4hSTStjERE9BYsr0W7CMBwGMGidg4hSbbAyFhHRU7C4Eu0BL9ER kSWOQUR7xuJKtAee5/HZiURkhmMQ0Z6xuBLtwVFHHXULgK3WOYgolbZWxiAi2g2LK9Ee9Pb2lkXk V9Y5iCh9RORXvb29ZescRC5icSXaiyiKrrTOQETpw7GHaO9YXIn2YufOndcCeNg6BxGlysOVsYeI 9oDFlWgvhoaGRkXkh9Y5iCg9ROSHQ0NDo9Y5iFzF4ko0CVXlnb1EVDccc4gml7UOQOSa5cuX79fY 2Himqp4L4CTrPESUKj8LguAmEblsdHT0qvXr1z9uHYjIJSyuRBMkCIJuAOcCOFNV5xvnIaJ0EgAv UtUXNTQ0XBIEwVUALgvDsA98FTURiyulm+/7bSJyLoBzADzHOg8R0VPMx8SH6XODIPgzgMtV9bJi sbjBOBeRGRZXSp0gCFpU9bUAzhWR46zzEBFNwXMAfExEPub7/h8AXCYiPwrDcJt1MKJ6YnGl1Mjl csdEUfR+AOeIyDzrPEREM1H5wH0cgC/6vn+553lfLBQKd1rnIqoHFldKvCAIOgFcoKqvFBE+SYOI kmKeiLxdVd8aBMFPAHwuDMO11qGIaonFlRLL9/1TReQCAN3WWYiIasgD8GoArw6CoE9VP1csFq+3 DkVUCyyulCg9PT2ZTZs2vUZVLwCwwjoPEVGddYtIdxAE60Tkc0cdddSVvb29ZetQRNXCy6aUCF1d XXN933/Xxo0b/6SqPwBLKxGl2wpV/cHGjRv/5Pv+u7q6uuZaByKqBhZXirXOzs4FQRB8bHR09M8i 8jUAR1lnIiJyyFEi8rXR0dE/B0Hwsc7OzgXWgYhmg8WVYqm7uzsbBMF7x8fH7wbwrwCeZZ2JiMhh zwLwr+Pj43cHQfDe7u5ubhWkWGJxpdjp6Oh48Y4dO9YB+DKAg63zEBHFyMEAvrxjx451HR0dL7YO QzRd/MRFsdHe3n5kNpu9WFXPsM5CRBRzz/c874ZcLnf1+Pj4BwYHBzdbByKaCq64kvO6urrmBkHw qUwmcztLKxFR9ajqGZlM5vYgCD7FG7goDlhcyWlBEPSMjo7eAeATAJqs8xARJVATgE+Mjo7eEQRB j3UYoslwqwA5KZfLvUBVvwLgJOssREQpcQSAK4MguElE3lsoFP5oHYhod1xxJacsW7bsgCAIvqKq g2BpJSKycJKqDgZB8JVly5YdYB2G6KlYXMkZvu+f0djYeAeA9wDIWOchIkqxDID3NDY23uH7Pu8t IGewuJK5pUuXzs/lcpeLyFUAnm2dh4iI/urZInJVLpe7fOnSpfOtwxCxuJKpfD7f3tTUFKrqG62z EBHRnqnqG5uamsJ8Pt9unYXSjcWVzARB8M4oim4BcLR1FiIi2qejoyi6JQiCd1oHofTiUwWo7oIg aAHwTQBnWWchIqJpmQPgv4IgeBGA/xeG4TbrQJQuXHGlusrn83kAJbC0EhHF2VkASpUxnahuWFyp bnK53PujKFoN4CjrLERENGtHRVG0OpfLvd86CKUHtwpQzXV1dR04Njb2HVU9zToLERFVVYOq/mcu lzupoaHhvDVr1jxiHYiSjSuuVFO5XG7V6OjoIEsrEVFyqeppo6Ojg7lcbpV1Fko2FleqmSAI3qmq fQAOt85CREQ1d7iq9vGpA1RLLK5UCxIEwecB/Be4HYWIKE2ymHjqwOcBiHUYSh4WV6o2z/f9bwL4 oHUQIiIy88HKXMCeQVXF1TCqmu7u7uz27dsvF5GzrbMQEZEtEXmL7/vzFixYcE5fX9+4dR5KBn4S oqpoa2ubs3379qtYWomIaBcROXv79u1XtbW1zbHOQsnA4kqzFgTBvJaWlp+KyOnWWYiIyC0icnpL S8tPgyCYZ52F4o/FlWZl1apVzSLyCwAvsc5CRETOeomI/GLVqlXN1kEo3lhcacaWLVt2wMjIyA2q eqJ1FiIicpuqnjgyMnLDsmXLDrDOQvHF4kozsnz58mc3NjbeBGCldRYiIoqNlY2NjTctX7782dZB KJ5YXGnaVqxYsaihoeG3AFZYZ4mJJ60DEFFd8FyfmhUNDQ2/XbFixSLrIBQ/LK40Le3t7Udms9nf AXiedRaHlQGsBvARVV0BwAfAR8EQJds4AL9yzn8EE2NA2TaS056XzWZ/197efqR1EIoXPseVpqy9 vf3ITCZzM4DDrLO4SEQKURR9J5vN/rC/v//hp/67IAj+B8A/GEUjotr7nzAM76j8/XoA/75y5cqD xsfHz/Y87zxVzVmGc9TiTCZzc3t7+wmDg4ObrcNQPLC40pTk8/lDoyi6ASytu3sAwPdE5DuFQuGP e/uPoii60PO8NwJYUL9oRFQn26MounD3/7HyAfYSAJfkcrkXqOp5AN4I4JD6xnPaYZlM5oZ8Pn/8 wMDA/dZhyH3cKkD71NXVNbdcLv8UwBLrLI4YE5GrVfX05ubmw8Iw/OBkpRUASqXSgwA+Xqd8RFRf H6+c43tVKBT+GIbhB5ubmw9T1dNF5GoAY3XK57ol5XL5p11dXXOtg5D7uOJK+yI7d+68XETy1kEc cDuASwH8oFAoPDTd3xyG4deCIOgBcHzVkxGRld+HYfi1qf7HlVef/gzAz4IgOBjA6wG8A8CxNcoX CyKS37lz5+UAegCodR5yF4srTSoIgn8HcKZ1DmO3APhcGIY/wewG1CiTyZxfLpfXAWiqTjQiMjSS yWTOBxDN5DeHYfgQgK8A+GoQBK8EcAGAF1YxX6yIyJlBEPxbGIb/Yp2F3MWtArRXuVzuLZgYSFNJ RK73PK87DMOuMAyvQRVWAfr7++9S1U9UIR4RGVPVT/T3999VjS8VhuE1YRh2eZ7XLSLXV+FrxtU/ V+Yeoj1icaU9CoLgJFW91DqHgTKAK6Ioai8UCi8dGBj4bbUPsGTJkv8E0F/tr0tEddVfOZeramBg 4LeFQuGlURS1A7gCKXyklqpeGgTBSdY5yE0srvQMK1euPArAVQAarLPU0QiAr3ued3QYhq8vlUrr anWg3t7esud5bwEwWqtjEFFNjXqe95be3t6alcpSqbQuDMPXe553NICvY2KMSosGAFdV5iKip2Fx padpa2ubUy6XfwwgTe+S/nEURc8Lw/AfBgYGNtbjgAMDA0MiclE9jkVE1SUiFw0MDAzV41gDAwMb wzD8hyiKngfgx/U4piMOKJfLP25ra5tjHYTcwuJKT9PS0vIfmHjTUxoMqeqLwzDsKZVKf673wefP n/85AKV6H5eIZqVUOXfre9BS6c9hGPao6osB1KU0O8CvzElEf8XiSn/l+/5pAN5rnaMOHgXwj83N ze3FYvFGqxB9fX3jlS0DfJYjUTyMeZ73lsojrUwUi8Ubm5ub2wH8IybGsqR7b2VuIgLA4koVnZ2d h4nIt61z1FgE4JtRFB0dhuGXLSefXQYGBgYBfNY6BxFNyWcr56ypvr6+8TAMvxxF0dEAvokZPo4r LkTk252dnXxrIwFgcSUAPT09mXK5/H0AB1lnqaFboijqDMPwrft6w029jYyMfBrApG/eIiJzf6yc q84olUoPhmH41iiKOjHxvOmkOqhcLn+/p6cnYx2E7LG4EjZt2vRxVT3ROkeNbFfVN4dheFypVCpY h9mToaGh0cqWgdQ99oYoJsqe571laGjIySeBlEqlQhiGx6nqm1Smk5YAABXKSURBVAFst85TC6p6 4qZNm/jabGJxTbtcLrdKVZM6GIQA/GKx+B04/grBgYGBAVW92DoHET2Tql48MDAwYJ1jH7Qy1vmY GPsSR1U/nsvlVlnnIFssrinW3d3dpKrfRjJ/Dr4yMjJyXBiGd1sHmart27d/AnzKAJFrSpVzMxbC MLx7ZGTkOEy8SjZpPFX9dnd3N1+ZnWJJLCw0Rdu3b/8YgOda56iyrQBeHYbh+1y9rLc3GzZs2Ol5 3llIx53CRHHwqOd5Z23YsGGndZDpGBoaGg3D8H0AXo2JMTFJnluZuyilWFxTyvf9Y0XkQ9Y5quyW KIo6wjC8xjrITA0MDGxU1TfB8a0NRCmgqvqmer2UpBbCMLwmiqIOJOzGLRH5kO/7x1rnIBssrukk nuddCqDROkiVKIAvADjR4kUC1VYsFn8GgA/dJrL1H5VzMdYqY+KJmBgjk/KBuLEyh4l1EKo/FtcU yuVyb07QUwQeFpFXhGH4oTAME/Mg/8WLF38UQJ91DqKU6qucg4kQhuFYGIYfEpFXAHjYOk81qOqJ uVzuzdY5qP5YXFMmCIKDVTUpq3n3ZjKZ4wqFwnXWQaqtt7e3nM1mzwYwbJ2FKGWGs9ns2b29vYl7 PF2hULguk8kcB+Be6yzVoKr/EQTBwdY5qL5YXNPnYiTjRQMby+XyCf39/XdZB6mVtWvXPhBF0dkA zN/wRZQS41EUnb127doHrIPUSn9//13lcvkEALHdu/sUB2FiTqMUYXFNkY6Oji4A51jnqII7oig6 YXBwcLN1kForlUq/U9WPWOcgSgNV/UipVPqddY5aGxwc3BxF0QkA7rDOUgXnVOY2SgkW1xQRkS8g /pvZ10VRdGKpVNpiHaReisXi5wHE9kkJRDFxTeVcS4VSqbQliqITAayzzjJLUpnbKCVYXFMiCIKX i8hx1jlmqX90dPSkUqn0oHUQA+cBiM3LFIhi5m5MnGOpUiqVHhwdHT0JQL91ltkQkeOCIHi5dQ6q DxbXdBAAn7EOMRsi8rumpqaTb7311qQ9THtKwjDcFkXRmQBGrLMQJcxIFEVnhmG4zTqIhVtvvXVr U1PTySIS9y0Sn0H8ryjSFLC4poDv+68BsMI6xyz8sqGh4dTVq1fvsA5iqVQqrRORd1nnIEoSEXlX qVSK++XyWVm9evWOhoaGUwH80jrLLKyozHWUcCyuCdfT05MRkYusc8zCT0ZGRk5fs2bNk9ZBXFAo FL4F4FLrHEQJcWnlnEq9NWvWPDkyMnI6gJ9YZ5kpEbmop6cnY52DaovFNeE2bdp0HoCjrXPM0K+b m5vPGhoaGrUO4pLFixe/G7xZi2i2rqmcS1QxNDQ02tzcfBaAX1tnmaGjK3MeJRiLa4K1tbXNUdVP WOeYoSEAPX19fXyG6W56///27j44rvK64/jv3JUtm1SCybSd2szA4BIoGAyShSlQiFoSQ4A4mSSG kCGBvABTCAkQ0lJIKUxISMJAIAxlMkOTcZnwYkFfMoFmWkKWuo6w9j5315gFBpyCwUYpiTECLK0l 7T39wzdjjPWykrU6z3P1+/zHDNZ+Z6S95+zuvXd7euptbW3nA1hn3UIUqHVtbW3n5/FLBvZXdsxd jd3H4OCo6g2HH354q3UHNQ8X1xxrb2+/EMAh1h3T8H9pmp49Vy+WaESxWKzV6/VVAJ6xbiEKzDP1 en1VsVjkhY7jyC4GPRtAiF/EcEg2+yinuLjml4jI1dYR0zAkIqvK5fIW6xDfVSqVN0dHR88E8Ip1 C1EgXhkdHT2zUqm8aR3iu3K5vEVEVgEI7vqCbPbxDgM5xcU1pzo7O1cCONK6Y6pE5Io4joO+p+Bs 2rhx4zYAZwDYbt1C5LntAM7InjPUgDiO+0TkCuuOaTgym4GUQ1xccyrQg83aOI7/yToiNM6551X1 HACD1i1EnhpU1XOcc3n4itNZlR2T11p3TFWgM5AawMU1h5YvX/6nAD5i3TFFWwBcYh0RqiRJnhKR 1QB4MRvR3kZFZHWSJE9ZhwTsEuw+RofkI9kspJzh4ppDqno5wvrd1qMo+gwvxto/cRw/BuBL1h1E nvlS9tygaXLODURR9BkAId2FIcpmIeVMSMsNNWDZsmXvE5EvWHdM0Y2lUulX1hF54JxbA+Ba6w4i T1ybPSdoP2XH6ButO6ZCRL6wbNmy91l30Mzi4poz8+bN+yyAA607piBZsmTJLdYReeKc+66I3GHd QWRJRO5wzn3XuiNPsmN1Yt0xBQdmM5FyhItr/oR0QnqapumlvAn4zIvj+GoA91t3EBm5P3sO0Azq 6empp2l6KYDUumUKQpqJ1AAurjnS0dFxGoCjrTum4O5yuRxbR+SULlmy5HOqep91CNFsUtX7lixZ 8jkAat2SR9kx+27rjik4OpuNlBNcXHMkiqLPWzdMwWstLS3fsI7Is56ennqSJBcCuMe6hWiW3JMk yYX8FKe5smP3a9YdjQpsNtIkuLjmxNKlS+cD+Lh1R6NE5KsbNmx4y7pjDlDn3GUicqt1CFEzicit zrnLwHdam27Dhg1vichXrTum4OPZjKQc4OKaEwsWLPgwgIOsOxqhqk/GcfywdcdcEsfx3wC4wbqD qEluyP7GaZbEcfywqj5p3dGgg7IZSTnAxTU/zrUOaFShULjOumEucs59U1Wvsu4gmkmqepVz7pvW HXNRYMfyYGYkTYyLaw5kH4F8zLqjQT/jPVvtJElyB4CLEdZVwURjSQFcnP1Nk4HsWP4z644GfYyn C+QDF9ccaG1tXYkw7t2qqnq9dcRc55y7V0QuAL8elsI1KiIXOOfutQ6Z67JjegjnFR+YzUoKHBfX fAjlI5AHkyR52jqCgDiOHxCRTwLYZd1CNEW7ROSTcRw/YB1CQHZMf9C6o0GhzEqaABfXwC1dunS+ iKyy7mhAWq/X/8E6gvaI4/inURSdA2CndQtRg3ZGUXROHMc/tQ6hPbJju/enH4nIKp4uED4uroFb uHDhhxDAaQIi8milUnnRuoP2ViqVHo+iaCWAAesWokkMRFG0slQqPW4dQnurVCovisij1h0NODCb mRQwLq6BU9WPWjc0QkR+YN1AYyuVSr+KoqgbwCvGKUTjeSWKom5e2OmvUI7xocxMGh8X1/Cdbh3Q gGf5LonfSqVSJU3TroDuy0hzhKo+maZpV6lUqli30PiyY/yz1h0NCGFm0gS4uAbsuOOOOxjAB6w7 GnCXdQBNrlwu/7a9vf1DIhLS95BTjonI3e3t7R8ql8u/tW6hhoRwrP9ANjspUFxcA1YoFP7SuqEB b46MjNxnHUGNKRaLo3Ecf1lEvgjecYDs7BKRL8Zx/OViscjbtgUiO9a/ad0xmUBmJ42Di2vYQnjy /ejpp5/mVeuBieP4RwA+COA16xaac14D8MHsb5ACkh3rQ/i9hTA7aRxcXAMmIt4/+VT1fusGmh7n 3AYAXSLSa91Cc0P2t9aV/e1RgEI45ocwO2l8XFwD1dHRcSiAw6w7JvFSkiTOOoKmzznXPzQ01A2A 31BEzXbv0NBQt3Ou3zqEpi875r9k3TGJw7IZSgHi4hqoEF4xisjD1g20/6rV6rBz7mIAlwMYse6h 3BkBcJlz7uJqtTpsHUP7L4RjfwgzlMbGxTVQITzpRKTHuoFmjnPuH1X1dACvW7dQbryuqqc75+6x DqGZE8KxP4QZSmPj4hquU60DJrGlVCqVrCNoZiVJsi6Koi5V5e+W9ouqlqIo6kqSZJ11C82s7Ni/ xbpjEr7PUBoHF9cAdXR0/BH8P7/1EesAao5SqfRqe3v7yap6I3jqAE3diKre2N7efnKpVHrVOoaa xvcZcFg2SykwXFzDtMw6YDJRFP2HdQM1T7FYHE2S5CYRORHAJuseCsYmETkxSZKbeH/WfAtkBng/ S2lfXFwDJCLHWjdMYrilpWW9dQQ1XxzH5Vqt1gXgFgB16x7yVh3ALbVarSuO47J1DDVfNgO8vtgu gFlKY+DiGiavn2wi8lRvb++QdQfNjuyuA9eJyMkAnrfuIe88LyInO+eu410D5o7e3t4hEXnKumMS Xs9SGhsX1zD5/mT7pXUAzb44jvva2to6ANwGILXuIXMpgNva2to64jjus44hE77PAt9nKY2Bi2t4 IhFZah0xkXq9/oR1A9koFos159w1InIagM3WPWRms4ic5py7plgs1qxjyIbvsyCbpdyDAsNfWGA6 OzuXADjAumMCQ8PDw75/PERNFsfxegDHAbgLgBrn0OxR7P6dH5f9DdAcls0Cn08bOyCbqRQQLq7h 8fqjDVVdz/PYCACcc4POua8AOB3Ay8Y51HwvAzjdOfcV59ygdQzZq1arw6rq+wsYr2cq7YuLa2B8 vwpSRP7buoH84pz7Za1WO1ZEvg2AHxvnT01Evl2r1Y51zvl+TiPNMt9ngu8zlfbFxTU8x1gHTERE nrZuIP9Uq9V34ji+PoqiIwD8BDx9IA8UwE+iKDoijuPrq9XqO9ZB5J8AZoLXM5X21WIdQFN2uHXA RESEN6OncWXflHRBR0fHHVEU3Q5+7WKo1qVpenW5XI6tQ8hvIrJJ1evXqV7PVNoX33ENz6HWARPY WSqVXrKOIP+Vy+XYOXeaqn4CwIvWPdSwF1X1E86507i0UiOymbDTumMCPs9UGgMX14B0d3cvAPB+ 644JVMGPgGkKkiT5VwBLAVwJ4A3jHBrfG9j9O1qa/c6IGqXYPRt89f5stlIguLgGZOfOnYutGybB 0wRoypxzI865O4eHhw8HcDs8/5rIOWYYwO3Dw8OHO+fudM6NWAdRkLyeDQHMVnoXLq4BSdPU6yeX qj5j3UDh2rRp0w7n3NcAHK2qj1j3zHXZ7+Bo59zXNm3atMO6h8Ll+2zwfbbS3nhxVkBU9WARsc4Y l4g8a91A4XPO/RrAp7q6uk5J0/R6ETkTgL9/+PmiqvrzKIq+5Zzz/f6bFAjfZ4OqHmzdQI3j4hqQ KIoW+3x1ZpqmW60bKD+yb146a/ny5X8mIlep6mcBLLTuyqkhEblPVb+fJMnz1jGUL2mabo0ifz/g jaKI77gGhItrQHx/VRhF0TbrBsof59zzAC5dsWLFdfV6/a8BXA7gT4yz8uI3AO4uFAr39PX1bbeO oXzyfTb4Pltpb/6+BKKx+PyqcKdzbsA6gvKrr69vu3Pu5lqtdiiAiwBsNE4K2UYAF9VqtUOdczdz aaVmymaDz7fE8nm20nvwHdeAiMjBHp8q4PUrasqParU6DGANgDWdnZ1/JSJXATgbPA92Mgrg0ex0 gCesY2jO2QbgCOuIsYgI33ENCBfXgKiqz68KeX4rzbpsAXtixYoVR9Tr9SsBXAjgAOMs3wwCWFMo FO7o6+t7wTqG5qyt8HRx9Xy20ntwcQ3LH1oHjEdV+Y4rmckWsstOOumkbwwPD39eRD6tql3WXZZE JFbVB+fPn//j3t5efrkDmVLVbR7fFcfb2Ur74uIaljbrgPGICBdXMpctaLcBuO2EE05YkqbpuQDO A3C8bdmsqQB4KIqitaVS6X+tY4h+z/MZ4e1spX1xcQ1Ed3d3y9tvv12w7hiP5wclmoOyxe07AL6T nUpwLoBzARxrWzbjNgFYWygU1vJUAPKViGzz+BqNQnd3d0uxWBy1DqHJcXENxMjIiNf3r0zTlN+s Q97KFrqbAdzc2dl5FIBzReQ8AEfZlk3bc6r6EIC1SZI8Zx1DNJk0TXd4fKrA72fs29YdNDkuroEY HBxc4PkNnGvWDUSNyBa9mwDc1NXVdYyqnofd78T67gUAa0XkoTiOvf4KTaL3iqKo5vE7rhgcHFwA Lq5B4OIaiCiKvH7HFcCQdQDRVGUL4DMA/n758uXzrHsm8Khz7t+sI4j2g9czIoAZSxl/38KjvYiI 10+qNE35jisFzTk3Yt0wHp/biBrh+4zwfcbSHlxcA1Gv1xdYN0ykUCh4fVAiIiI7vs8I32cs7cHF NRC+vxpUVa8/BiIiIju+zwjfZyztwcU1EFEUef1q0PePgYiIyI7vM8L3GUt7cHENh9evBltaWrw+ KBERkZ0AZoTXM5b24OIaDq9vjOz7x0BERGTH9xmRpqm/9+qivXBxDUQURZutGyYyf/78ndYNRETk p8HBwXesGybCb38MBxfXQPT19W0BsMu6Yxzb1q9fzxs3ExHRmKrV6jsAfm3dMZ56vf6qdQM1hotr OFIAXr7rqqpPWzcQEZH3NlgHjOOdSqXypnUENYaLa1hesA4Yi4hwcSUiosn4urhutQ6gxnFxDYuX iysALq5ERDQZXxdXniYQEC6uARERLxdXvuNKRESTGRgYqAAYtu54L1XtsW6gxnFxDcjo6OgT8O9J //xhhx32nHUEERH5bfPmzbsAVKw73uM3b7311j9bR1DjuLgGpFKpvKyqd1t3vJuIXNvT01O37iAi Iv+p6mPWDe9xZ7ZQUyC4uAamtbX1ZgC+XP34P3Ec/7t1BBERhaG1tfV78Oe2WG8DuMc6gqaGi2tg ent73wDwLesOAFDVr1s3EBFROHp7e4dU9RLrjswPnXMD1hE0NVxcAzQwMHAXgC2WDar6SJIkT1k2 EBFReJIkeUJEfmycMTw6OnqHcQNNAxfXAGXn41xnmDCapunfGT4+EREFbN68edcAeN0w4fqNGzfy a14DVLAOoOnp7+9/ZtGiRUeKyDGz/NCpiFyZJMnPZ/lxiYgoJ7Zu3Tq0aNGiV0XkU7P92CLyt865 W2f7cWlmcHENWH9//78sXry4FcBfzNJD1kTk/DiO18zS4xERUU719/dXFy9evADAKQBklh7261xa w8bFNXD9/f2/WLx48TYAZ6G5p378Lk3TM5Mk+c8mPgYREc0h/f39v1i0aJETkTMBLGzyw13jnLut yY9BTTZbr3Coybq6uj6sqg8DaG/Cj99cr9fPqlQqLzbhZxMR0Ry3fPnyQwCsBXBiM36+iFwdx/H3 m/GzaXbx4qyciOP4v0TkFAAvz/CPXpem6clcWomIqFmcc68AOFVVZ3S5VNXHRWQll9b84DuuObN6 9erCSy+9dIaqXgRgFYDWafyY7ar6gKquKZfL8cwWEhERja+zs/McEbkCQDeA+dP4ESOq+qCq3lYu lzfObB1Z4+KaY8cff/xBhULh0wAuBPDnk/zvIwAeU9U1u3bterRarQ43v5CIiGhsS5cu/YPW1taV IvJR7L6O448n+ScDqvrDer3+A97qKr+4uM4RK1asOCJN06MAaJqmKiKpiOi7/jt2zv3OupOIiGgM UWdn5woAp4pITVV3iMiOKIp2pGn6RktLy46FCxduLxaLo9ahRERERERERERERERERERERERERERE RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE RERERERERERERERERERERERERERERERERERERERERERERLny/4VyFCZV1lKsAAAAAElFTkSuQmCC  "
+     height="264.01248"
+     width="371.84085"
+     style="fill:#ffffff;fill-opacity:1" />
+</svg>

--- a/src/ress.qrc
+++ b/src/ress.qrc
@@ -14,5 +14,6 @@
         <file>resources/arrow_up.png</file>
         <file>resources/profile_rate.png</file>
         <file>resources/computer_B.svg</file>
+        <file>resources/debugMode.svg</file>
     </qresource>
 </RCC>

--- a/src/ress.qrc
+++ b/src/ress.qrc
@@ -13,5 +13,6 @@
         <file>resources/arrow_down.png</file>
         <file>resources/arrow_up.png</file>
         <file>resources/profile_rate.png</file>
+        <file>resources/computer_B.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
 Now the ports are grouped by modules and the modules by hostname. These changes has introduced some bugs, I have to fix it before merging.
Add the possibility to hide disconnected ports and ports/process linked to debug
Now yarpviz has this visualization: 
![image](https://cloud.githubusercontent.com/assets/19152494/25221758/87de6c72-25b6-11e7-9a38-ba509064c8e5.png)
